### PR TITLE
fixing the title for AMQP conventions

### DIFF
--- a/docs/monorail/amqp_conventions.rst
+++ b/docs/monorail/amqp_conventions.rst
@@ -1,4 +1,5 @@
-# AMQP message bus conventions
+AMQP message bus conventions
+============================
 
 At the top level, we utilize 9 exchanges for passing various messages between key services and processes:
 


### PR DESCRIPTION
fixes the title in amqp_conventions.rst that makes the ToC a bit more sane