### PR TITLE
Fixing Format Under HTTP Key

### DIFF
--- a/docs/monorail/configuration.rst
+++ b/docs/monorail/configuration.rst
@@ -68,6 +68,7 @@ monorail.json
 * `syslogport` UDP port for listening for syslog messages
 
 ### HTTP
+
 * `httpsCert` Filename of SSL certificate
 * `httpsKey` Filename of RSA private key
 * `httpsPfx` pfx file containing the SSL cert and private key (only needed if the key and cert are omitted)


### PR DESCRIPTION
The entries under ##HTTP were displaying as one paragraph, instead of a list.

Also, some of the entries in the JSON file are not explained, but review this later.