### PR TITLE
Replace instance of M&0 with M&O (zero vs. O)

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -4,7 +4,7 @@ In a Converged Infrastructure Platform (CIP) architecture, RackHD software provi
 
 Once RackHD is installed on the managed CIP platform, it has the ability to discover the existing hardware resources, catalog each component, and retrieve detailed telemetry information from each resource. The retrieved information can then be used to perform low-level hardware management functions for each resource, such as BIOS configuration, OS installation, and firmware management.
 
-RackHD sits between the other M&0 layers and the underlying physical hardware devices. User interfaces at the higher M&O layers can request hardware services from RackHD. RackHD handles the details of connecting to and managing the hardware devices.
+RackHD sits between the other M&O layers and the underlying physical hardware devices. User interfaces at the higher M&O layers can request hardware services from RackHD. RackHD handles the details of connecting to and managing the hardware devices.
 
 Management Paradigm
 ----------------------------


### PR DESCRIPTION
There was a zero instead of an 'O' in one instance of M&O.

@bossidy @christineday 