### PR TITLE
Update NodeJS references to Node.js. Remove Python as a language in t…

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -20,11 +20,11 @@ Applications
      - Description
    * - on-tftp
      - https://github.com/RackHD/on-tftp
-     - | Nodejs application provided TFTP service integrated
+     - | Node.js application provided TFTP service integrated
        | with the workflow engine.
    * - on-http
      - https://github.com/RackHD/on-http
-     - | Nodejs application provided TFTP service integrated
+     - | Node.js application provided TFTP service integrated
        | with the workflow engine.
    * - on-syslog
      - https://github.com/RackHD/on-syslog
@@ -32,10 +32,10 @@ Applications
        | the workflow engine.
    * - on-taskgraph
      - https://github.com/RackHD/on-taskgraph
-     - | Nodejs application providing the workflow engine.
+     - | Node.js application providing the workflow engine.
    * - on-dhcp-proxy
      - https://github.com/RackHD/on-dhcp-proxy
-     - | Nodejs application providing DHCP proxy support
+     - | Node.js application providing DHCP proxy support
        | integrated into the workflow engine.
 
 Libraries
@@ -49,10 +49,10 @@ Libraries
      - Description
    * - core
      - https://github.com/RackHD/on-core
-     - Core libraries in use across NodeJS applications.
+     - Core libraries in use across Node.js applications.
    * - tasks
      - https://github.com/RackHD/on-tasks
-     - NodeJS task library for the workflow engine.
+     - Node.js task library for the workflow engine.
 
 
 Supplemental code

--- a/docs/how_it_works.rst
+++ b/docs/how_it_works.rst
@@ -27,7 +27,7 @@ Discovery tasks are performed sequentially:
    the remote machine and reports them back to RackHD, which adds this information to the machine record.
 
 #. RackHD then responds with an additional iPXE script that downloads
-   and runs the microkernel. The microkernel boots up and requests a NodeJS "bootstrap" program
+   and runs the microkernel. The microkernel boots up and requests a Node.js "bootstrap" program
    from RackHD. RackHD runs the bootstrap program which uses a simple REST API to "ask" what it should do on the remote host from RackHD. The workflow engine,
    running the discovery workflow, provides a set of tasks to run. These tasks are matched with parsers in RackHD to understand and store the output. They work
    together to run Linux commands that interrogate the hardware from the microkernel running in memory. These commands include interrogating the machines BMC
@@ -89,7 +89,7 @@ simple logic (as demonstrated in the discovery workflow) to perform arbitrarily
 complex tasks based on the workflow definition. The workflow definitions
 themselves are accessible through the Monorail engine's REST API as a "graph"
 of "tasks". Both graphs and tasks are fully declarative with a JSON format.
-Tasks are also mapped up "Jobs", which is the NodeJS code that's included
+Tasks are also mapped up "Jobs", which is the Node.js code that's included
 within RackHD. 
 
 Workflow Graphs

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ physical hardware.
 
 The project is a collection of libraries and applications housed at https://github.com/RackHD/
 and documentation hosted at http://rackhd.readthedocs.org. The code for RackHD is a combination
-of Python, Javascript (NodeJS), and C, available under the Apache 2.0 license (or
+of Javascript/Node.js and C, available under the Apache 2.0 license (or
 compatible sublicences for library dependencies).
 
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -76,7 +76,7 @@ The RackHD Project
 
 RackHD is an open source project available under the Apache 2.0 license (or
 compatible sub-licenses for library dependencies). It is housed at https://github.com/RackHD.
-The code for RackHD is a combination of Python, Javascript (NodeJS), and C. The project is a collection
+The code for RackHD is a combination of Javascript/Node.js and C. The project is a collection
 of libraries and applications intended to be deployed together to provide a solution that can be used
 either standalone, or as a technology to be included and embedded in larger applications.
 

--- a/docs/monorail/configuration.rst
+++ b/docs/monorail/configuration.rst
@@ -74,7 +74,7 @@ Setting        | Description
 server         | IP address of interface to bind to for TFTP, SYSLOG and HTTP services.
                |
                | **Note:** DHCP binds to 0.0.0.0 to support broadcast request/response within
-               | NodeJS.
+               | Node.js.
 broadcastaddr  | Broadcast address for the network range (for DHCP)
 subnetmask     | Subnet mask for the network range (for DHCP)
 iprange        | Range of IP addresses, either in CIDR format or a list of IP addresses

--- a/docs/monorail/microkernel.rst
+++ b/docs/monorail/microkernel.rst
@@ -27,7 +27,7 @@ Overlays:
 The overlay files are CPIO archives with additional "user-space" programs added
 into them. The initramfs loads the base OS, and then overlays the CPIO archive,
 and the resulting image contains common Linux tooling and immediately loads and
-runs a NodeJS task-runner that is built and rendered on the fly to the microkernel
+runs a Node.js task-runner that is built and rendered on the fly to the microkernel
 to invoke commands on the remote machine as needed. This process is embedded
 into the overlay itself, and relies on parameters passed into it through PXE
 using `/proc/commandline` and the kernel parameters.


### PR DESCRIPTION
…he codebase

Mainly replacing NodeJS with what I think is the official name: Node.js

I also updated the codebase language list from

`... Python, Javascript (NodeJS), and C`

to

`... Javascript/Node.js and C`

Since with the exclusion of certain repos I don't think we have any more Python, and also because of on-web-ui, we use Javascript both with and without the Node.js environment.

Let me know if you think this should be different :)

@christineday @bossidy 