### PR TITLE
Fix various broken rst tables, update configuration guide

### DIFF
--- a/docs/monorail/configuration.rst
+++ b/docs/monorail/configuration.rst
@@ -8,40 +8,40 @@ The following JSON is an examples of the current defaults:
 
 .. code-block:: JSON
 
-{
-    "CIDRNet": "172.31.128.0/22",
-    "amqp": "amqp://localhost",
-    "apiServerAddress": "172.31.128.1",
-    "apiServerPort": 8080,
-    "broadcastaddr": "172.31.131.255",
-    "dhcpGateway": "172.31.128.1",
-    "dhcpProxyBindAddress": "172.31.128.1",
-    "dhcpProxyBindPort": 4011,
-    "dhcpSubnetMask": "255.255.252.0",
-    "gatewayaddr": "172.31.128.1",
-    "httpBindAddress": "0.0.0.0",
-    "httpBindPort": 8080,
-    "httpDocsRoot": "./build/apidoc",
-    "httpEnabled": true,
-    "httpFileServiceRoot": "./static/files",
-    "httpFileServiceType": "FileSystem",
-    "httpStaticRoot": "/opt/monorail/static/http",
-    "httpsBindAddress": "0.0.0.0",
-    "httpsBindPort": 8443,
-    "httpsCert": "data/dev-cert.pem",
-    "httpsEnabled": false,
-    "httpsKey": "data/dev-key.pem",
-    "httpsPfx": null,
-    "mongo": "mongodb://localhost/pxe",
-    "sharedKey": "<key>",
-    "statsd": "127.0.0.1:8125",
-    "subnetmask": "255.255.252.0",
-    "syslogBindAddress": "172.31.128.1",
-    "syslogBindPort": 514,
-    "tftpBindAddress": "172.31.128.1",
-    "tftpBindPort": 69,
-    "tftpRoot": "./static/tftp"
-}
+  {
+      "CIDRNet": "172.31.128.0/22",
+      "amqp": "amqp://localhost",
+      "apiServerAddress": "172.31.128.1",
+      "apiServerPort": 8080,
+      "broadcastaddr": "172.31.131.255",
+      "dhcpGateway": "172.31.128.1",
+      "dhcpProxyBindAddress": "172.31.128.1",
+      "dhcpProxyBindPort": 4011,
+      "dhcpSubnetMask": "255.255.252.0",
+      "gatewayaddr": "172.31.128.1",
+      "httpBindAddress": "0.0.0.0",
+      "httpBindPort": 8080,
+      "httpDocsRoot": "./build/apidoc",
+      "httpEnabled": true,
+      "httpFileServiceRoot": "./static/files",
+      "httpFileServiceType": "FileSystem",
+      "httpStaticRoot": "/opt/monorail/static/http",
+      "httpsBindAddress": "0.0.0.0",
+      "httpsBindPort": 8443,
+      "httpsCert": "data/dev-cert.pem",
+      "httpsEnabled": false,
+      "httpsKey": "data/dev-key.pem",
+      "httpsPfx": null,
+      "mongo": "mongodb://localhost/pxe",
+      "sharedKey": "<key>",
+      "statsd": "127.0.0.1:8125",
+      "subnetmask": "255.255.252.0",
+      "syslogBindAddress": "172.31.128.1",
+      "syslogBindPort": 514,
+      "tftpBindAddress": "172.31.128.1",
+      "tftpBindPort": 69,
+      "tftpRoot": "./static/tftp"
+  }
 
 Keys
 ~~~~~~~~~~~~~~~~~~
@@ -49,71 +49,80 @@ Keys
 Queue
 ^^^^^^^^^^^^^^^^^^^^^^
 
-=============== ===============================================================================
-Setting           Description
-=============== ===============================================================================
-amqp            | URI for accessing the AMQP interprocess communications channel
-=============== ===============================================================================
-
-Persistence
-^^^^^^^^^^^^^^^^^^^^^^
-
-============= ===================================================================================
-Setting         Description
-============= ===================================================================================
-dbURI         | The URI for accessing an instance of MongoDB database used for persistence.
-databasetype  | Back-end persistence for the DHCP lease data. "MEMORY-MONGODB" is
-              | the only valid value until additional back-end lease persistence support is
-              | added.
-============= ===================================================================================
+================= ===================================================================================
+Setting             Description
+================= ===================================================================================
+amqp              | URI for accessing the AMQP interprocess communications channel
+================= ===================================================================================
 
 Networking
 ^^^^^^^^^^^^^^^^^^^^^^
 
-============== ===================================================================================
-Setting        | Description
-============== ===================================================================================
-server         | IP address of interface to bind to for TFTP, SYSLOG and HTTP services.
-               |
-               | **Note:** DHCP binds to 0.0.0.0 to support broadcast request/response within
-               | Node.js.
-broadcastaddr  | Broadcast address for the network range (for DHCP)
-subnetmask     | Subnet mask for the network range (for DHCP)
-iprange        | Range of IP addresses, either in CIDR format or a list of IP addresses
-               | to provide via DHCP
-http           | Toggle HTTP
-https          | Toggle HTTPS
-httpPort       | HTTP port for support API (internal and public) requests
-httpsPort      | HTTPS port for support API (internal and public) requests
-tftpport       | DP port for supporting TFTP requests
-syslogport     | UDP port for listening for syslog messages
-============== ===================================================================================
-
+==================== ===================================================================================
+Setting              | Description
+==================== ===================================================================================
+apiServerAddress     | Externally facing IP address that the API server can be accessed at.
+apiServerPort        | Externally facing port that the API server can be accessed at.
+==================== ===================================================================================
 
 HTTP
 ^^^^^^^^^^^^^^^^^^^^^^
 
-================== ===================================================================================
-Setting            | Description
-================== ===================================================================================
-httpsCert          | Filename of SSL certificate
-httpsKey           | Filename of RSA private key
-httpsPfx           | pfx file containing the SSL cert and private key (only needed if
-                   | the key and cert are omitted)
-maxTaskPayloadSize | maximum payload size expected through TASK runner API callbacks from
-                   | microkernel
-================== ===================================================================================
+==================== ===================================================================================
+Setting              | Description
+==================== ===================================================================================
+httpEnabled          | Toggle HTTP.
+httpsEnabled         | Toggle HTTPS.
+httpBindAddress      | ip/interface to bind to for HTTP. Typically this is '0.0.0.0'
+httpBindPort         | Local port to use for HTTP. Typically this is port 80
+httpsBindPort        | Local port to use for HTTPS. Typically this is port 443.
+httpsCert            | Filename of the X.509 certificate to use for TLS. Expected format is PEM.
+httpsKey             | Filename of the RSA private key to use for TLS. Expected format is PEM.
+httpFileServiceRoot  | Directory path for uploaded files to be stored on disk.
+httpFileServiceType  | backend storage mechanism for file service. Currently only FileSystem is supported.
+httpsCert            | Filename of SSL certificate
+httpsKey             | Filename of RSA private key
+httpsPfx             | pfx file containing the SSL cert and private key (only needed if
+                     | the key and cert are omitted)
+maxTaskPayloadSize   | maximum payload size expected through TASK runner API callbacks from
+                     | microkernel
+==================== ===================================================================================
 
-
-Workflows
+DHCP
 ^^^^^^^^^^^^^^^^^^^^^^
 
-================= ===================================================================================
-Setting           | Description
-================= ===================================================================================
-defaultWorkflow   | name of the default workflow to be invoked upon new machine discovery
-                  | (only functional if `promiscuous` is also enabled)
-================= ===================================================================================
+==================== ===================================================================================
+Setting              | Description
+==================== ===================================================================================
+dhcpGateway          | Gateway IP for the network (for DHCP)
+dhcpProxyBindAddress | IP for DHCP proxy server to bind to (defaults to '0.0.0.0').
+                     | **Note:** DHCP binds to 0.0.0.0 to support broadcast request/response within
+                     | Node.js.
+dhcpProxyBindPort    | Port for DHCP proxy server to bind to (defaults to 4011).
+dhcpProxyOutPort     | Port for DHCP proxy server to respond to legacy boot clients on (defaults to 68).
+dhcpProxyEFIOutPort  | Port for DHCP proxy server to respond to EFI clients on (defaults to 4011).
+==================== ===================================================================================
+
+TFTP
+^^^^^^^^^^^^^^^^^^^^^^
+
+==================== ===================================================================================
+Setting              | Description
+==================== ===================================================================================
+tftpBindAddress      | Address for TFTP server to bind to (defaults to '0.0.0.0').
+tftpBindPort         | Port for TFTP server to listen on (defaults to 69).
+tftpBindAddress      | File root for TFTP server to serve files from (defaults to './static/tftp').
+==================== ===================================================================================
+
+Syslog
+^^^^^^^^^^^^^^^^^^^^^^
+
+==================== ===================================================================================
+Setting              | Description
+==================== ===================================================================================
+syslogBindPort       | Port for syslog (defaults to 514).
+syslogBindAddress    | Address for the syslog server to bind to (defaults to '0.0.0.0').
+==================== ===================================================================================
 
 Pollers
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -147,12 +156,6 @@ httpFrontendDirectory   | Fully-qualified directory to the web GUI content
 httpApiDocsDirectory    | Fully-qualified directory to the API docs
 tftproot                | Fully-qualified directory to where static TFTP content is served
 ======================= ===================================================================================
-
-Logging
-^^^^^^^^^^^^^^^^^^^^^^
-
-* verbose
-* color
 
 Debugging
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/monorail/https.rst
+++ b/docs/monorail/https.rst
@@ -16,21 +16,31 @@ Configuration
 The following options are present in /opt/onrack/etc/monorail.json to control the HTTP/HTTPS
 server:
 
-===================  =========  ===================================================================================
-Name                  Type      Description
-===================  =========  ===================================================================================
-httpEnabled           boolean   Toggle HTTP.
-httpsEnabled          boolean   Toggle HTTPS.
-httpBindAddress       string    ip/interface to bind to for HTTP. Typically this is 0.0.0.0
-httpBindPort          integer   Local port to use for HTTP. Typically this is port 80
-httpsBindPort         integer   Local port to use for HTTPS. Typically this is port 443.
-httpsCert             string    Filename of the X.509 certificate to use for TLS. Expected format is PEM.
-httpsKey              string    Filename of the RSA private key to use for TLS. Expected format is PEM.
-apiServerAddress      string    The externally facing ip of the HTTP server, used by various services
-apiServerPort         integer   The externally facing port of the HTTP server, used by various services
-httpFileServiceRoot   string    Directory path for uploaded files to be stored on disk
-httpFileServiceType   string    Backend storage mechanism for file service. Currently only FileSystem is supported
-===================   ========  ===================================================================================
++---------------------+---------+------------------------------------------------------------------------------------+
+| Name                |  Type   |  Description                                                                       |
++=====================+=========+====================================================================================+
+| httpEnabled         | boolean | Toggle HTTP.                                                                       |
++---------------------+---------+------------------------------------------------------------------------------------+
+| httpsEnabled        | boolean | Toggle HTTPS.                                                                      |
++---------------------+---------+------------------------------------------------------------------------------------+
+| httpBindAddress     | string  | ip/interface to bind to for HTTP. Typically this is 0.0.0.0                        |
++---------------------+---------+------------------------------------------------------------------------------------+
+| httpBindPort        | integer | Local port to use for HTTP. Typically this is port 80                              |
++---------------------+---------+------------------------------------------------------------------------------------+
+| httpsBindPort       | integer | Local port to use for HTTPS. Typically this is port 443.                           |
++---------------------+---------+------------------------------------------------------------------------------------+
+| httpsCert           | string  | Filename of the X.509 certificate to use for TLS. Expected format is PEM.          |
++---------------------+---------+------------------------------------------------------------------------------------+
+| httpsKey            | string  | Filename of the RSA private key to use for TLS. Expected format is PEM.            |
++---------------------+---------+------------------------------------------------------------------------------------+
+| apiServerAddress    | string  | The externally facing ip of the HTTP server, used by various services              |
++---------------------+---------+------------------------------------------------------------------------------------+
+| apiServerPort       | integer | The externally facing port of the HTTP server, used by various services            |
++---------------------+---------+------------------------------------------------------------------------------------+
+| httpFileServiceRoot | string  | Directory path for uploaded files to be stored on disk                             |
++---------------------+---------+------------------------------------------------------------------------------------+
+| httpFileServiceType | string  | Backend storage mechanism for file service. Currently only FileSystem is supported |
++---------------------+---------+------------------------------------------------------------------------------------+
 
 Generating Self-Signed Certificates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/monorail/skus.rst
+++ b/docs/monorail/skus.rst
@@ -179,21 +179,38 @@ SKU JSON format
 
 SKUs are defined via JSON, with these required fields:
 
-| Name                  | Type     | Flags                    | Description                                               |
-|-----------------------|----------|--------------------------|-----------------------------------------------------------|
-| name                  | String   | **required**, **unique** | Unique name identifying this SKU definition.              |
-| rules                 | Object[] | **required**             | Array of validation rules that define the SKU.            |
-| rules[].path          | String   | **required**             | Path into the catalog to validate against.                |
-| rules[].equals        | \*       | *optional*               | Exact value to match against.                             |
-| rules[].in            | \*[]     | *optional*               | Array of possibly valid values.                           |
-| rules[].notIn         | \*[]     | *optional*               | Array of possibly invalid values.                         |
-| rules[].contains      | String   | *optional*               | A string that the value should contain.                   |
-| rules[].notContains   | String   | *optional*               | A string that the value should not contain.               |
-| rules[].greaterThan   | Number   | *optional*               | Number that the value should be greater than.             |
-| rules[].lessThan      | Number   | *optional*               | Number that the value should be less than.                |
-| rules[].min           | Number   | *optional*               | Number that the value should be greater than or equal to. |
-| rules[].max           | Number   | *optional*               | Number that the value should be less than or equal to.    |
-| rules[].regex         | String   | *optional*               | A regular expression that the value should match.         |
-| rules[].notRegex      | String   | *optional*               | A regular expression that the value should not match.     |
-| discoveryGraphName    | String   | *optional*               | Name of graph to run against matching nodes on discovery. |
-| discoveryGraphOptions | Object   | *optional*               | Options to pass to the graph being run on node discovery. |
++------------------------+-----------+--------------------------+----------------------------------------------------------+
+| Name                   |  Type     | Flags                    | Description                                              |
++========================+===========+==========================+==========================================================+
+| name                   |  String   | **required**, **unique** | Unique name identifying this SKU definition.             |
++------------------------+-----------+--------------------------+----------------------------------------------------------+
+| rules                  |  Object[] | **required**             | Array of validation rules that define the SKU.           |
++------------------------+-----------+--------------------------+----------------------------------------------------------+
+| rules[].path           |  String   | **required**             | Path into the catalog to validate against.               |
++------------------------+-----------+--------------------------+----------------------------------------------------------+
+| rules[].equals         |  \*       | *optional*               | Exact value to match against.                            |
++------------------------+-----------+--------------------------+----------------------------------------------------------+
+| rules[].in             |  \*[]     | *optional*               | Array of possibly valid values.                          |
++------------------------+-----------+--------------------------+----------------------------------------------------------+
+| rules[].notIn          |  \*[]     | *optional*               | Array of possibly invalid values.                        |
++------------------------+-----------+--------------------------+----------------------------------------------------------+
+| rules[].contains       |  String   | *optional*               | A string that the value should contain.                  |
++------------------------+-----------+--------------------------+----------------------------------------------------------+
+| rules[].notContains    |  String   | *optional*               | A string that the value should not contain.              |
++------------------------+-----------+--------------------------+----------------------------------------------------------+
+| rules[].greaterThan    |  Number   | *optional*               | Number that the value should be greater than.            |
++------------------------+-----------+--------------------------+----------------------------------------------------------+
+| rules[].lessThan       |  Number   | *optional*               | Number that the value should be less than.               |
++------------------------+-----------+--------------------------+----------------------------------------------------------+
+| rules[].min            |  Number   | *optional*               | Number that the value should be greater than or equal to.|
++------------------------+-----------+--------------------------+----------------------------------------------------------+
+| rules[].max            |  Number   | *optional*               | Number that the value should be less than or equal to.   |
++------------------------+-----------+--------------------------+----------------------------------------------------------+
+| rules[].regex          |  String   | *optional*               | A regular expression that the value should match.        |
++------------------------+-----------+--------------------------+----------------------------------------------------------+
+| rules[].notRegex       |  String   | *optional*               | A regular expression that the value should not match.    |
++------------------------+-----------+--------------------------+----------------------------------------------------------+
+| discoveryGraphName     |  String   | *optional*               | Name of graph to run against matching nodes on discovery.|
++------------------------+-----------+--------------------------+----------------------------------------------------------+
+| discoveryGraphOptions  |  Object   | *optional*               | Options to pass to the graph being run on node discovery.|
++------------------------+-----------+--------------------------+----------------------------------------------------------+


### PR DESCRIPTION
Fixing broken tables that were missed during the markdown to rst conversion.

Looking now, it seems I deviated from the alternative/simpler rst table syntax used other places in the code. Let me know if anyone cares enough that they want me to update this so we have a standard rst table syntax convention, otherwise I'll leave it.

I also fixed the configuration.rst json code block, and updated the configuration sections and descriptions.