### PR TITLE
Update summary sentence for monorail/microkernel doc

### DIFF
--- a/docs/monorail/microkernel.rst
+++ b/docs/monorail/microkernel.rst
@@ -1,7 +1,7 @@
 MicroKernel and Overlays
 ----------------------------------------------------------
 
-RackHD uses microkernal images and overlay filesystems to deploy operating systems on managed hardware.
+RackHD utilizes microkernel images booted in RAM to perform various operations such as node discovery and firmware management.
 
 The `on-imagebuilder`_ repository contains a set of ansible playbooks and roles used for building
 debian-based linux microkernel images and overlay filesystems. They are primarily used with


### PR DESCRIPTION
@bossidy A suggested language change. The previous sentence suggests that we use images to deploy things, rather than images being a tool utilized as part of deployment. Let me know what you think of this suggestion.

Also, misspelled kernel.