### PR TITLE
Modify instructions about auto-rebuild command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ build the docs
 to auto-rebuild docs while you're editing
 
     cd docs
-    sphinx-autobuild . _build/html
+    sphinx-autobuild -H 0.0.0.0 -p 8000 . _build/html
 
-and the docs will be visible at the url http://127.0.0.1:8000
+and the docs will be visible at the url http://&lt;server ip>:8000  
+the default is http://127.0.0.1:8000
 
 ## Setting up for editing and building the docs (Windows)
 
@@ -60,7 +61,8 @@ start .\_build\html\index.html
 * to auto-rebuild the docs on editing with live updates
 
 ```
-sphinx-autobuild . _build\html
+sphinx-autobuild -H 0.0.0.0 -p 8000 . _build/html
 ```
 
-and navigate to http://127.0.0.1:8000/ to see the docs
+and navigate to http://&lt;server ip>:8000 to see the docs  
+the default url is http://127.0.0.1:8000


### PR DESCRIPTION
Modify instructions about auto-rebuild command in readme, thus modified docs can be view from outside the dev machine. Thanks @anhou for pointing this out.