### PR TITLE
reordering contribution section to focus on community interactions first

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -8,22 +8,12 @@ Since our project is relatively new, we don't yet have many hard and fast rules.
 people get involved, we will solidify and extend our guidelines as needed.
 
 
+Communicating with Other Users
+-----------------------------------------
 
+We maintain a mailing list at https://groups.google.com/d/forum/rackhd. You can visit the group through the web page or subscribe directly by sending email to rackhd+subscribe@googlegroups.com.
 
-Understand the Repositories
--------------------------------------------------
-
-The https://github.com/rackhd/RackHD repository acts as a single source location to help you get or build all the pieces to learn about, take advantage of, and contribute to RackHD.
-
-A thorough understanding of the individual repositories is essential for contributing to the project. The repositories are described in our documentation
-at :doc:`repositories`.
-
-
-Submitting Design Proposals
-----------------------------------------
-
-To submit a new design proposal, please follow the procedure described in the RackHD specs repository https://github.com/RackHD/specs.
-
+We also have a #RackHD slack channel at https://codecommunity.slack.com/messages/rackhd/. You can receive an invite by requesting one at http://community.emccode.com.
 
 
 Submitting Contributions
@@ -38,7 +28,7 @@ Run your changes against existing tests or create new ones if needed. Keep tests
 
 After receiving the pull request, our core committers will give you feedback on your work and may request that you make further changes and resubmit the request. The core committers will handle all merges.
 
-If you have questions about the disposition of a  request, feel free to email one of our core committers:
+If you have questions about the disposition of a request, feel free to email one of our core committers:
 
 * Ben.BroderickPhillips@emc.com
 * Felix.Yuan@emc.com
@@ -46,12 +36,13 @@ If you have questions about the disposition of a  request, feel free to email on
 * Andrew.Hou@emc.com
 * Brian.Parry@emc.com
 
+Please direct general conversation about how to use RackHD or discussion about improvements and features to our mailing list at rackhd@googlegroups.com
 
 
 Issues and Bugs
 -----------------------------------
 
-Use the **Issues** section of each repository to raise issues, ask questions, and report bugs.
+Please use https://github.com/rackhd/rackhd/issues to raise issues, ask questions, and report bugs.
 
 Search existing issues to ensure that you do report a topic that has already been covered. If you have new information to share about an existing issue, add your information to the existing discussion.
 
@@ -68,18 +59,26 @@ Security Issues
 
 If you discover a security issue, please report it in an email to rackhd@emc.com. Do not use the Issues section to describe a security issue.
 
+Understand the Repositories
+-------------------------------------------------
+
+The https://github.com/rackhd/RackHD repository acts as a single source location to help you get or build all the pieces to learn about, take advantage of, and contribute to RackHD.
+
+A thorough understanding of the individual repositories is essential for contributing to the project. The repositories are described in our documentation
+at :doc:`repositories`.
+
+
+Submitting Design Proposals
+----------------------------------------
+
+To submit a new design proposal, please follow the procedure described in the RackHD specs repository https://github.com/RackHD/specs.
+
 
 Coding Guidelines
 -----------------------------------
 
-Use the same coding style as the rest of the codebase. In general, write clean code and supply meaningful and comprehensive code comments.
-
-See the following sections in our documentation for guidance about a number of our standard practices:
-
-* :doc:`devguide/naming_conventions`
-* :doc:`devguide/api_versioning`
-* :doc:`devguide/amqp_conventions`
-
+Use the same coding style as the rest of the codebase. In general, write clean code and supply meaningful and comprehensive code comments. For more
+detailed information about how we've set up our code, please see our :doc:`devguide/index`.
 
 
 Contributing to the Documentation
@@ -89,14 +88,6 @@ To contribute to our documentation, clone the `RackHD/docs`_ repository and subm
 When we merge your pull requests, your changes are automatically published to our documentation site at http://rackhd.readthedocs.org/en/latest/.
 
 .. _RackHD/docs: https://github.com/RackHD/docs
-
-Communicating with Other Users
------------------------------------------
-
-We maintain a mailing list at https://groups.google.com/d/forum/rackhd. You can visit the group through the web page or subscribe directly by sending email to rackhd+subscribe@googlegroups.com.
-
-We also have a #RackHD slack channel at https://codecommunity.slack.com/messages/rackhd/. You can receive an invite by requesting one at http://community.emccode.com.
-
 
 
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -54,12 +54,14 @@ When reporting problems, include the following information:
 * Expected Results
 * Additional Information
 
+
 Security Issues
 ------------------------------
 
 If you discover a security issue, please report it in an email to rackhd@emc.com. Do not use the Issues section to describe a security issue.
 
-Understand the Repositories
+
+Understanding the Repositories
 -------------------------------------------------
 
 The https://github.com/rackhd/RackHD repository acts as a single source location to help you get or build all the pieces to learn about, take advantage of, and contribute to RackHD.


### PR DESCRIPTION
shifting around the ordering of the contributions page to focus on how to get involved with the community first and foremost - pushing email and the mailing list to the top of the proverbial heap

This change also explicitly asks folks to use https://github.com/RackHD/RackHD/issues for registering bugs - we may need to fix them across each of the repos, but asserting a single place to go seemed like a better idea.