### PR TITLE
fix unmatched curly braces

### DIFF
--- a/docs/rackhd/nodes.rst
+++ b/docs/rackhd/nodes.rst
@@ -121,7 +121,7 @@ Sample Output:
 
     curl -X PATCH \
         -H 'Content-Type: application/json' \
-        -d '{ "obmSettings": [ { "service": "ipmi-obm-service", "config": { "host": "10.1.1.3", "user": "admin", "password": "admin" } ] }' \
+        -d '{ "obmSettings": [ { "service": "ipmi-obm-service", "config": { "host": "10.1.1.3", "user": "admin", "password": "admin" } } ] }' \
         {server}/api/1.1/nodes/{nodeID}
 
 


### PR DESCRIPTION
When I want to copy the command to add an obm setting to my newly discovered node, I found the command in the docs was not correct, it missed a curly braces.

@RackHD/corecommitters @heckj 