### PR TITLE
local must come after -c in ansible-playbook command line

### DIFF
--- a/docs/rackhd/ubuntu_source_installation.rst
+++ b/docs/rackhd/ubuntu_source_installation.rst
@@ -15,7 +15,7 @@ We will leverage the ansible roles created for the RackHD demonstration environm
     git clone https://github.com/rackhd/rackhd
     sudo apt-get install ansible
     cd ~/rackhd/packer/ansible
-    ansible-playbook -i "local," -c -K local rackhd_local.yml
+    ansible-playbook -i "local," -K -c local rackhd_local.yml
 
 This created the default configuration file at /opt/monorail/etc/config.json
 from https://github.com/RackHD/RackHD/blob/master/packer/ansible/roles/monorail/files/config.json.


### PR DESCRIPTION
I hit an error when trying to execute this command as documented:

ansible-playbook -i "local," -c -K local rackhd_local.yml

I believe the "local" is supposed to come after the "-c".  Otherwise, I get the error "ERROR: the playbook: local could not be found"