### PR TITLE
changev vlanId to vlanIds

### DIFF
--- a/docs/rackhd/install_os.rst
+++ b/docs/rackhd/install_os.rst
@@ -117,7 +117,7 @@ Parameters  Type     Flags        Description
 ipAddr      String   **required** The assigned static IP address
 gateway     String   **required** The gateway.
 netmask     String   **required** The subnet mask.
-vlanId      Number   *optional*   The VLAN ID. This is an array of integers (0-4095)
+vlanIds     Array    *optional*   The VLAN ID. This is an array of integers (0-4095)
 =========== ======== ============ ============================================
 
 

--- a/docs/rackhd/samples/install-os-maximal-parameters.json
+++ b/docs/rackhd/samples/install-os-maximal-parameters.json
@@ -29,13 +29,13 @@
                         "ipAddr": "192.168.1.29",
                         "gateway": "192.168.1.1",
                         "netmask": "255.255.255.0",
-                        "vlanId": [104, 105]
+                        "vlanIds": [104, 105]
                     },
                     "ipv6": {
                         "ipAddr": "fec0::6ab4:0:5efe:157.60.14.21",
                         "gateway": "fe80::5efe:131.107.25.1",
                         "netmask": "ffff.ffff.ffff.ffff.0.0.0.0",
-                        "vlanId": [101, 106]
+                        "vlanIds": [101, 106]
                     }
                 },
                 {
@@ -44,13 +44,13 @@
                         "ipAddr": "192.168.11.89",
                         "gateway": "192.168.11.1",
                         "netmask": "255.255.255.0",
-                        "vlanId": [105, 109]
+                        "vlanIds": [105, 109]
                     },
                     "ipv6": {
                         "ipAddr": "fec0::6ab4:0:5efe:159.45.14.11",
                         "gateway": "fe80::5efe:131.107.25.100",
                         "netmask": "ffff.ffff.ffff.ffff.0.0.0.0",
-                        "vlanId": [106, 108]
+                        "vlanIds": [106, 108]
                     }
                 }
             ],


### PR DESCRIPTION
1.old 'vlanId' should not be used anymore, 'vlanIds' is recommanded now. but 'vlanId' is still supported with deprecated message.
2.this PR is integrated with https://github.com/RackHD/on-http/pull/290 and https://github.com/RackHD/on-tasks/pull/215
@RackHD/corecommitters @yyscamper @anhou @panpan0000 please review.