### PR TITLE
Simplified toc nav

### DIFF
--- a/docs/_templates/localtoc.html
+++ b/docs/_templates/localtoc.html
@@ -1,1 +1,0 @@
-{{ toctree(maxdepth=4, collapse=True, includehidden=True) }}

--- a/docs/_templates/navbar.html
+++ b/docs/_templates/navbar.html
@@ -46,7 +46,7 @@
           {% endif %}
         </ul>
 
-        {% block navbarsearch %}{#% include "navbarsearchbox.html" %#}{% endblock %}
+        {% block navbarsearch %}{% include "navbarsearchbox.html" %}{% endblock %}
 
         <ul class="nav navbar-nav navbar-right">
           {% include "relations.html" %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -150,7 +150,7 @@ html_theme_options = {
 
     # Global TOC depth for "site" navbar tab. (Default: 1)
     # Switching to -1 shows all levels.
-    # 'globaltoc_depth': 2,
+    'globaltoc_depth': -1,
 
     # Include hidden TOCs in Site navbar?
     # Note: If this is "false", you cannot have mixed ``:hidden:`` and
@@ -219,11 +219,7 @@ html_static_path = ['_static']
 #html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {
-  '*': ['searchbox.html', 'localtoc.html'],
-  'devguide/*': ['searchbox.html', 'localtoc.html'],
-  'rackhd/*': ['searchbox.html', 'localtoc.html'],
-}
+#html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.

--- a/docs/devguide/index.rst
+++ b/docs/devguide/index.rst
@@ -1,10 +1,12 @@
 RackHD Development Guide
 ========================
 
-.. include:: contributing.rst
-.. include:: naming_conventions.rst
-.. include:: api_versioning.rst
-.. include:: amqp_conventions.rst
-.. include:: messenger_overview.rst
-.. include:: log_levels.rst
-.. include:: debugging_guide.rst
+.. toctree::
+
+   contributing.rst
+   naming_conventions.rst
+   api_versioning.rst
+   amqp_conventions.rst
+   messenger_overview
+   log_levels.rst
+   debugging_guide.rst

--- a/docs/rackhd/index.rst
+++ b/docs/rackhd/index.rst
@@ -1,24 +1,26 @@
 RackHD Users Guide
 ==================
 
-.. include:: rackhd_api.rst
-.. include:: configuration.rst
-.. include:: authentication.rst
-.. include:: authorization.rst
-.. include:: nodes.rst
-.. include:: graphs.rst
-.. include:: tasks.rst
-.. include:: skus.rst
-.. include:: tags.rst
-.. include:: install_os.rst
-.. include:: secure_erase.rst
-.. include:: workflow_examples.rst
-.. include:: passive_discovery.rst
-.. include:: switch_active_discovery.rst
-.. include:: pollers.rst
-.. include:: microkernel.rst
-.. include:: web_ui.rst
-.. include:: dhcp_server.rst
-.. include:: arp_poller.rst
-.. include:: boot_settings.rst
-.. include:: ssdp.rst
+.. toctree::
+
+   rackhd_api
+   configuration
+   authentication
+   authorization
+   nodes
+   graphs
+   tasks
+   skus
+   tags
+   install_os
+   secure_erase
+   workflow_examples
+   passive_discovery
+   switch_active_discovery
+   pollers
+   microkernel
+   web_ui
+   dhcp_server
+   arp_poller
+   boot_settings
+   ssdp


### PR DESCRIPTION
Per conversation on the google group forum from a few weeks back, removing the sidebar navigation structures in the sphinx documentation, and changing from a mechanism that uses `.. include::` directives in ReStructuredText to the more common `.. toctree::` directives for structuring a hierarchy of documents in Sphinx. This change includes putting the searchbox into the title/navbar page structure as well.

The rough looks - before:

![before](https://cloud.githubusercontent.com/assets/43388/16782519/cfe76df8-4834-11e6-9277-b6a9ac39c7a2.png)

and after:

![after](https://cloud.githubusercontent.com/assets/43388/16782527/d6071a3a-4834-11e6-9434-7526db374bc2.png)

