### PR TITLE
Add a vlan comment  for the windows os install

### DIFF
--- a/docs/rackhd/install_os.rst
+++ b/docs/rackhd/install_os.rst
@@ -140,8 +140,8 @@ Parameters  Type     Flags        Description
 ipAddr      String   **required** The assigned static IP address
 gateway     String   **required** The gateway.
 netmask     String   **required** The subnet mask.
-vlanIds     Array    *optional*   The VLAN ID. This is an array of integers (0-4095)
-                                  *In the case of windows, the vlan is an array of paramter  
+vlanIds     Array    *optional*   The VLAN ID. This is an array of integers (0-4095).
+                                  In the case of Windows OS, the vlan is an array of one parameter only  
 =========== ======== ============ ============================================
 
 

--- a/docs/rackhd/install_os.rst
+++ b/docs/rackhd/install_os.rst
@@ -141,6 +141,7 @@ ipAddr      String   **required** The assigned static IP address
 gateway     String   **required** The gateway.
 netmask     String   **required** The subnet mask.
 vlanIds     Array    *optional*   The VLAN ID. This is an array of integers (0-4095)
+                                  *In the case of windows, the vlan is an array of paramter  
 =========== ======== ============ ============================================
 
 


### PR DESCRIPTION
Windows only allows one vlan ID per port