### PR TITLE
Ubuntu requirements for DHCP

### DIFF
--- a/docs/rackhd/samples/dhcpd-non-rackhd.conf
+++ b/docs/rackhd/samples/dhcpd-non-rackhd.conf
@@ -13,5 +13,7 @@ ignore-client-uids true;
 subnet 172.31.128.0 netmask 255.255.240.0 {
  range 172.31.128.3 172.31.143.254;
  # Use this option to signal to the PXE client that we are doing proxy DHCP
+ # Even not doing proxy DHCP, it's essential, otherwise, monorail-undionly.kpxe
+ # would not DHCP successfully.
  option vendor-class-identifier "PXEClient";
 }

--- a/docs/rackhd/samples/dhcpd-non-rackhd.conf.noproxy
+++ b/docs/rackhd/samples/dhcpd-non-rackhd.conf.noproxy
@@ -16,6 +16,13 @@ option arch-type code 93 = unsigned integer 16;
 subnet 172.31.128.0 netmask 255.255.240.0 {
  range 172.31.128.3 172.31.143.254;
  next-server 172.31.128.1;
+
+ # It's essential for Ubuntu installation
+ option routers 172.31.128.1;
+ # It's essential for Ubuntu installation
+ option domain-name-servers 172.31.128.1;
+
+ # It's essential, otherwise, monorail-undionly.kpxe would not DHCP successfully.
  option vendor-class-identifier "PXEClient";
 
  # Register leased hosts with RackHD

--- a/docs/rackhd/samples/dhcpd.conf
+++ b/docs/rackhd/samples/dhcpd.conf
@@ -13,5 +13,7 @@ ignore-client-uids true;
 subnet 172.31.128.0 netmask 255.255.240.0 {
  range 172.31.128.2 172.31.143.254;
  # Use this option to signal to the PXE client that we are doing proxy DHCP
+ # Even not doing proxy DHCP, it's essential, otherwise, monorail-undionly.kpxe
+ # would not DHCP successfully.
  option vendor-class-identifier "PXEClient";
 }

--- a/docs/rackhd/samples/dhcpd.conf.noproxy
+++ b/docs/rackhd/samples/dhcpd.conf.noproxy
@@ -16,6 +16,13 @@ option arch-type code 93 = unsigned integer 16;
 subnet 172.31.128.0 netmask 255.255.240.0 {
  range 172.31.128.2 172.31.143.254;
  next-server 172.31.128.1;
+
+ # It's essential for Ubuntu installation
+ option routers 172.31.128.1;
+ # It's essential for Ubuntu installation
+ option domain-name-servers 172.31.128.1;
+
+ # It's essential, otherwise, monorail-undionly.kpxe would not DHCP successfully.
  option vendor-class-identifier "PXEClient";
 
  # Register leased hosts with RackHD


### PR DESCRIPTION
DHCP needs to specify `option routers` and `option domain-name-servers` in dhcpd.conf for Ubuntu network installation

@RackHD/corecommitters @WangWinson 