### PR TITLE
Add api-usage-examples.rst into RackHD Users Guide toctree to make it visible

### DIFF
--- a/docs/rackhd/index.rst
+++ b/docs/rackhd/index.rst
@@ -31,3 +31,4 @@ RackHD Users Guide
    ssdp
    heartbeat
    event_notification.rst
+   api-usage-examples


### PR DESCRIPTION
api-usage-examples.rst was created but disconnected in RackHD Users Guide page so that it won't be displayed.  This PR is to resolve this problem. 
@RackHD/corecommitters @uppalk1 