### PR TITLE
Process manager is changed to PM2 instead of Foreman

### DIFF
--- a/docs/rackhd/ubuntu_source_installation.rst
+++ b/docs/rackhd/ubuntu_source_installation.rst
@@ -30,7 +30,18 @@ that it will be run with `pm2`_.
 .. code::
 
     cd ~
-    sudo pm2 start rackhd.yml
+    sudo pm2 start rackhd-pm2-config.yml
+
+Some useful commands of pm2:
+
+.. code::
+
+    sudo pm2 restart all           # restart all RackHD services
+    sudo pm2 restart on-taskgraph  # restart the on-taskgraph service only.
+    sudo pm2 logs                  # show the combined real-time log for all RackHD services
+    sudo pm2 logs on-taskgraph     # show the on-taskgraph real-time log
+    sudo pm2 flush                 # clean the RackHD logs
+    sudo pm2 status                # show the status of RackHD services
 
 
 How to update to the latest code

--- a/docs/rackhd/ubuntu_source_installation.rst
+++ b/docs/rackhd/ubuntu_source_installation.rst
@@ -23,12 +23,14 @@ You may need to update this and /etc/dhcpd.conf to match your local network
 configuration.
 
 This will install all the relevant dependencies and code into ~/src, expecting
-that it will be run with node-foreman.
+that it will be run with `pm2`_.
+
+.. _pm2: http://pm2.keymetrics.io/
 
 .. code::
 
     cd ~
-    sudo nf start
+    sudo pm2 start rackhd.yml
 
 
 How to update to the latest code

--- a/docs/tutorials/vagrant.rst
+++ b/docs/tutorials/vagrant.rst
@@ -89,7 +89,7 @@ The Vagrant setup also enables port forwarding that allows your localhost to acc
 
 .. code::
 
-    vagrant ssh dev -c "sudo pm2 start rackhd.yml"
+    vagrant ssh dev -c "sudo pm2 start rackhd-pm2-config.yml"
 
 The logs from RackHD will show in the console window where you invoked this last
 command. You can use control-c (^C) to stop the processes. Additionally you can
@@ -109,7 +109,7 @@ Accessing your local instance of RackHD
 
         vagrant destroy -f
         vagrant up dev
-        vagrant ssh dev -c "sudo pm2 start rackhd.yml"
+        vagrant ssh dev -c "sudo pm2 start rackhd-pm2-config.yml"
 
 
     **Resetting and updating the code to the latest master branch**
@@ -133,7 +133,7 @@ Accessing your local instance of RackHD
 
     Once that is complete, you can exit your SSH sessions with the VM and start all the services::
 
-        vagrant ssh dev -c "sudo pm2 start rackhd.yml"
+        vagrant ssh dev -c "sudo pm2 start rackhd-pm2-config.yml"
 
 When RackHD is operational, the self-hosted API documentation should immediately
 be available:

--- a/docs/tutorials/vagrant.rst
+++ b/docs/tutorials/vagrant.rst
@@ -89,7 +89,7 @@ The Vagrant setup also enables port forwarding that allows your localhost to acc
 
 .. code::
 
-    vagrant ssh dev -c "sudo nf start"
+    vagrant ssh dev -c "sudo pm2 start rackhd.yml"
 
 The logs from RackHD will show in the console window where you invoked this last
 command. You can use control-c (^C) to stop the processes. Additionally you can
@@ -109,7 +109,7 @@ Accessing your local instance of RackHD
 
         vagrant destroy -f
         vagrant up dev
-        vagrant ssh dev -c "sudo nf start"
+        vagrant ssh dev -c "sudo pm2 start rackhd.yml"
 
 
     **Resetting and updating the code to the latest master branch**
@@ -133,7 +133,7 @@ Accessing your local instance of RackHD
 
     Once that is complete, you can exit your SSH sessions with the VM and start all the services::
 
-        vagrant ssh dev -c "sudo nf start"
+        vagrant ssh dev -c "sudo pm2 start rackhd.yml"
 
 When RackHD is operational, the self-hosted API documentation should immediately
 be available:


### PR DESCRIPTION
use PM2 instead of foreman to  manage rackhd process.
see GG https://groups.google.com/forum/#!topic/rackhd/UfyZ1v9Gdc4

This PR should be merged at the same time with https://github.com/RackHD/RackHD/pull/479  after new version vagrant box be updated.

Related PR:
* https://github.com/RackHD/RackHD/pull/478  edit packer script, change foreman to pm2.
* https://github.com/RackHD/RackHD/pull/479  edit RackHD readme 
* https://github.com/RackHD/on-build-config/pull/31 edit Vagrantfile for smoke-test
@panpan0000 

