### PR TITLE
Add CentOS6.5 deprecation message for rsync source

### DIFF
--- a/docs/rackhd/install_os.rst
+++ b/docs/rackhd/install_os.rst
@@ -140,6 +140,10 @@ For the Ubuntu repo, you need some additional installation. The mirrors are easi
     #end of file
     ###################
 
+**Reference: Here are some useful links to vendor's official website about Mirros setup.**
+
+* **CentOS**: `Creating Local Mirrors for Updates or Installs <https://wiki.centos.org/HowTos/CreateLocalMirror>`_
+
 Supported OS Installation Workflows
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/rackhd/install_os.rst
+++ b/docs/rackhd/install_os.rst
@@ -65,6 +65,8 @@ Making the Mirrors
 
 **Centos 6.5**
 
+Notes: Because CentOS 6.5 was deprecated by provider, the following rsync source is not available to 
+make mirror. Just leave it for an example.
   .. code::
 
     sudo rsync --progress -av --delete --delete-excluded --exclude "local*" \


### PR DESCRIPTION
As the response to https://github.com/RackHD/RackHD/issues/442 (CentOS 6.5 is deprecated, and need changes to docs and code #442), I added the CentOS 6.5 deprecation notification message for the mirror rsync source because it doesn't work now.

@RackHD/corecommitters @lanchongyizu  