### PR TITLE
Remove src code relevant operation in Vagrant Box

### DIFF
--- a/docs/tutorials/vagrant.rst
+++ b/docs/tutorials/vagrant.rst
@@ -85,11 +85,6 @@ The Vagrant setup also enables port forwarding that allows your localhost to acc
 
     vagrant up dev
 
-- Start the local instance
-
-.. code::
-
-    vagrant ssh dev -c "sudo pm2 start rackhd-pm2-config.yml"
 
 The logs from RackHD will show in the console window where you invoked this last
 command. You can use control-c (^C) to stop the processes. Additionally you can
@@ -109,31 +104,8 @@ Accessing your local instance of RackHD
 
         vagrant destroy -f
         vagrant up dev
-        vagrant ssh dev -c "sudo pm2 start rackhd-pm2-config.yml"
 
 
-    **Resetting and updating the code to the latest master branch**
-
-    The demonstration instance of RackHD is installed from source, so it can also be
-    updated the latest version::
-
-        vagrant destroy -f
-        vagrant up dev
-        vagrant ssh dev
-
-    And then within that virtual machine::
-
-        cd ~/src
-        ./scripts/clean_all.bash
-        ./scripts/reset_submodules.bash
-        ./scripts/link_install_locally.bash
-
-    .. WARNING::
-        This downloads the latest code and reinstalls it all from source, which can take a few minutes.
-
-    Once that is complete, you can exit your SSH sessions with the VM and start all the services::
-
-        vagrant ssh dev -c "sudo pm2 start rackhd-pm2-config.yml"
 
 When RackHD is operational, the self-hosted API documentation should immediately
 be available:


### PR DESCRIPTION
**Previous**
RackHD vagrant boxes were uploaded to ATLAS manually before (last was V0.16).
and those old vagrant box are install/run with source code.
so the ~/src inside that box tent to get rusty..
then Joe.H added a session (in snapshot below) in ReadTheDoc, with some scripts , to “Resetting and updating the code to the latest master branch” .
Because there will be a long time between when customer use box and when V0.16 box was created . so reset to latest code is important for vagrant user.

**Current**
Thanks to @Alan. We have below now: 
* current vagrant box are build based on debian package( run as service) . Which will start automatically without additional “nf start” or “pm2 start”.
* Nightly Build Vagrant Box published to ATLAS( with version naming 0.dd.mm , example 0.07.15 means build on July 15th . read more in confluence page )

**Change**
So with daily basis box available (we can’t cd ~/src to update code now… )we may not need the session (“Resetting and updating the code to the latest master branch”).  End-user can ```vagrant init rackhd/rackhd --box-version 0.01.17``` to get nightly build of yesterday’s build. ( not 100% latest, but new enough) 
Moreover, If end-user want to install from source code and using latest code, RTD Chapter 6.5 has all the details  . And this is not relevant/restricted to Vagrant environment. 


@heckj @anhou @changev 