### PR TITLE
change obmSettings to obms

### DIFF
--- a/docs/rackhd/nodes.rst
+++ b/docs/rackhd/nodes.rst
@@ -25,7 +25,8 @@ Nodes are defined via a JSON definition that conform to this schema:
 - sku (string): the SKU 'id' that has been matched from the SKU workflow task
 - createdAt (string): ISO8601 date string of time resource was created
 - updatedAt (string): ISO8601 date string of time resource was last updated
-- identifiers (array of strings): a list of strings that make up alternative identifiers for the node.
+- identifiers (array of strings): a list of strings that make up alternative identifiers for the node
+- obms (array of objects): a list of objects that define out-of-band management access mechanisms
 - relations (array of objects): a list of relationship objects
 
 

--- a/docs/rackhd/passive_discovery.rst
+++ b/docs/rackhd/passive_discovery.rst
@@ -89,7 +89,7 @@ using different settings. For example, a smart PDU:
          "options":{"defaults":{"nodeId": "55b6afba024fd1b349afc148"}}}' \
         <server>/api/1.1/nodes/55b6afba024fd1b349afc148/workflows
 
-And a management server (or other server you do not want to or ca not to reboot
+And a management server (or other server you do not want to or cannot to reboot
 to interrogate)
 
 .. code-block:: REST
@@ -97,7 +97,7 @@ to interrogate)
     curl -X POST \
         -H 'Content-Type: application/json' \
         -d '{"name":"nodeName", "type": "compute", \
-        "obmSettings": [ { "service": "ipmi-obm-service", "config": { "host": "10.1.1.3",  \
+        "obms": [ { "service": "ipmi-obm-service", "config": { "host": "10.1.1.3",  \
         "user": "admin", "password": "admin" } } ] }' \
         <server>/api/current/nodes
 

--- a/docs/rackhd/samples/discovered-compute-node.json
+++ b/docs/rackhd/samples/discovered-compute-node.json
@@ -7,9 +7,9 @@
         "08:00:27:27:eb:12"
     ],
     "name": "08:00:27:27:eb:12",
-    "obmSettings": [
+    "obms": [
         {
-            "config": {},
+            "ref": "/api/2.0/obms/58806bb776fab9d82b831e52",
             "service": "noop-obm-service"
         }
     ],


### PR DESCRIPTION
Since now the obm has been moved into a standalone database model, and the key has been changed from `obmSettings` to `obms` in node document, so to manually create a node should also use the `obms` rather than `obmSettings`.

Below PR changes the logic while posting a node:
https://github.com/RackHD/on-http/pull/524

This PR is to change to document accordingly.

@manfrednde @brianparry @iceiilin @anhou 

