### PR TITLE
add DHCP service checking message to make sure isc-dhcp-server is started

### DIFF
--- a/docs/rackhd/ubuntu_package_installation.rst
+++ b/docs/rackhd/ubuntu_package_installation.rst
@@ -127,6 +127,19 @@ These will install the prerequisite packages, install the RackHD debian packages
 All the services are started and have logs in /var/log/rackhd.
 Verify with ``service on-[something] status``
 
+Notes：isc-dhcp-server is installed through ansible playbook, but sometimes it won't start on Ubuntu boot (https://ubuntuforums.org/showthread.php?t=2068111), 
+check if DHCP service is started:
+
+.. code::
+
+    sudo service --status-all
+
+If isc-dhcp-server is not running, run below to start DHCP service:
+
+.. code::
+
+    sudo service isc-dhcp-server start
+
 
 _`Install/Configure with Step by Step Guide`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -194,7 +207,7 @@ Update dhcpd.conf per your network configuration
       option vendor-class-identifier "PXEClient";
     }
 
-isc-dhcp-server is installed through ansible script, but sometimes it won't start on Ubuntu boot (https://ubuntuforums.org/showthread.php?t=2068111), 
+Notes：sometimes isc-dhcp-server won't start on Ubuntu boot (https://ubuntuforums.org/showthread.php?t=2068111), 
 check if DHCP service is started:
 
 .. code::

--- a/docs/rackhd/ubuntu_package_installation.rst
+++ b/docs/rackhd/ubuntu_package_installation.rst
@@ -194,6 +194,19 @@ Update dhcpd.conf per your network configuration
       option vendor-class-identifier "PXEClient";
     }
 
+isc-dhcp-server is installed through ansible script, but sometimes it won't start on Ubuntu boot (https://ubuntuforums.org/showthread.php?t=2068111), 
+check if DHCP service is started:
+
+.. code::
+
+    sudo service --status-all
+
+If isc-dhcp-server is not running, run below to start DHCP service:
+
+.. code::
+
+    sudo service isc-dhcp-server start
+
 
 #######
 

--- a/docs/rackhd/ubuntu_source_installation.rst
+++ b/docs/rackhd/ubuntu_source_installation.rst
@@ -32,6 +32,19 @@ that it will be run with `pm2`_.
     cd ~
     sudo pm2 start rackhd-pm2-config.yml
 
+isc-dhcp-server is installed through ansible script, but sometimes it won't start on Ubuntu boot (https://ubuntuforums.org/showthread.php?t=2068111), 
+check if DHCP service is started:
+
+.. code::
+
+    sudo service --status-all
+
+If isc-dhcp-server is not running, run below to start DHCP service:
+
+.. code::
+
+    sudo service isc-dhcp-server start
+
 Some useful commands of pm2:
 
 .. code::

--- a/docs/rackhd/ubuntu_source_installation.rst
+++ b/docs/rackhd/ubuntu_source_installation.rst
@@ -32,7 +32,18 @@ that it will be run with `pm2`_.
     cd ~
     sudo pm2 start rackhd-pm2-config.yml
 
-isc-dhcp-server is installed through ansible script, but sometimes it won't start on Ubuntu boot (https://ubuntuforums.org/showthread.php?t=2068111), 
+Some useful commands of pm2:
+
+.. code::
+
+    sudo pm2 restart all           # restart all RackHD services
+    sudo pm2 restart on-taskgraph  # restart the on-taskgraph service only.
+    sudo pm2 logs                  # show the combined real-time log for all RackHD services
+    sudo pm2 logs on-taskgraph     # show the on-taskgraph real-time log
+    sudo pm2 flush                 # clean the RackHD logs
+    sudo pm2 status                # show the status of RackHD services
+
+Notes：isc-dhcp-server is installed through ansible playbook, but sometimes it won't start on Ubuntu boot (https://ubuntuforums.org/showthread.php?t=2068111), 
 check if DHCP service is started:
 
 .. code::
@@ -44,17 +55,6 @@ If isc-dhcp-server is not running, run below to start DHCP service:
 .. code::
 
     sudo service isc-dhcp-server start
-
-Some useful commands of pm2:
-
-.. code::
-
-    sudo pm2 restart all           # restart all RackHD services
-    sudo pm2 restart on-taskgraph  # restart the on-taskgraph service only.
-    sudo pm2 logs                  # show the combined real-time log for all RackHD services
-    sudo pm2 logs on-taskgraph     # show the on-taskgraph real-time log
-    sudo pm2 flush                 # clean the RackHD logs
-    sudo pm2 status                # show the status of RackHD services
 
 
 How to update to the latest code


### PR DESCRIPTION
add DHCP service checking message after RackHD installation, to make sure isc-dhcp-server is started. 
and RAC-3898 is about isc-dhcp-server not started on Ubuntu boot issue.