### PR TITLE
Add extra install dependency packages

### DIFF
--- a/docs/rackhd/npm_based_installation.rst
+++ b/docs/rackhd/npm_based_installation.rst
@@ -87,6 +87,8 @@ Prerequisites
 
   .. code::
 
+    sudo apt-get install build-essential
+    sudo apt-get install libkrb5-dev
     sudo apt-get install rabbitmq-server
     sudo apt-get install mongodb
     sudo apt-get install snmp


### PR DESCRIPTION
Because lack of some libraries `g++` and `libkrb5-dev`, building kerberos will failed so I added the following command at the beginning of [http://rackhd.readthedocs.io/en/latest/rackhd/npm_based_installation.html](http://rackhd.readthedocs.io/en/latest/rackhd/npm_based_installation.html)
`sudo apt-get install build-essential`
`sudo apt-get install  libkrb5-dev`
