### PR TITLE
update docs to RancherOS from old Microkernel

### DIFF
--- a/docs/devguide/debugging_guide.rst
+++ b/docs/devguide/debugging_guide.rst
@@ -6,7 +6,7 @@ Discovery with a Default Workflow
 
 Sequence Diagram for the Discovery Workflow
 
-.. image:: https://www.websequencediagrams.com/cgi-bin/cdraw?lz=dGl0bGUgRGVmYXVsdCBEaXNjb3ZlcnkgV29ya2Zsb3cKICAgIFNlcnZlci0-UmFja0hEOiBESENQIGZyb20gUFhFKG5pYyBvciBCSU9TKQAqBQAhBi0-ADEGOiBJU0MALQZyZXNwb25zZSB3aXRoIElQABkVREhDUC1wcm94eQAhD2Jvb3RmaWxlAIEOBW5vdGUgcmlnaHQgb2YAawc6IElmIHRoZSBub2RlIGlzIGFscmVhZHkgImtub3duIiwgaXQgd2lsbCBvbmwAVghkIGkAMAVyZSdzIGFuIGFjdGl2ZSB3AIF5ByB0aGF0J3MgYmVlbiBpbnZva2VkIHJlbGF0ZWQgdG8AZgkAghMVUmVxdWVzdCB0byBkb3dubG9hZACBPQkgdmlhIFRGVACBbxZURlRQIHNlbmRzIHIAPwZlZCAAMgUobW9ub3JhaWwuaXB4ZQCCawYAgggFbGVmAIIHBQCCbggAgy8GIGxvYWRzIAAoDSBhbmQgaW5pdGlhdGVzIG9uAIJWBWxvYWRlcgCDWxVJUFhFIHNjcmlwdACBBwhzIHdoYQCBUwcAhAUGAIQXBiAoaHR0cACBDAsAgxQQAIRMBSAgICBtdWx0aWxpbgCDSgYAhC4KIGxvb2tzIHVwIElQIGFkZHJlc3Mgb2YgSFRUUACCBQgAhHcGaQCBDAt0byBmaW5kAIN1CnZpYSBpdHMgbWFjLQA_By4AcwkAgymAfwBxEm4ndCAAhSAFAIUaCmNyZWF0ZSBhAIUBCihkAIcgB2lzAIViBQCFGwknR3JhcGguU2t1LgCHOQknKQCDYgUAhV0IAIZtBWFuAIIkEACDfggAhWIFAIMSCWVuZACGXAUAhzkVAIJqDCgAhAAFAINzB2NhbGxzIGEgUHJvZmlsZSkgKHZpYSAAhAAPAIUWEACDOAwAiBEFZACIegltaWNyb2tlcm5lbACFKQlyZACEVQwAiQgQAIQMBQCFGAlzdGF0aWMAhjAGLQCIEwV2bWxpbnV6IABPBgCJFxUAGwgALzcAgR4GAIIiFgCBLhEAhxUidGhlAIEmBwCBdgxhbmQgdHJhbnNmZXJzIGNvbnRyb2wgKGJvb3RzAIkrBQCCLwwAghMXAIJGBgCIFwZhZGRpdGlvbmFsAIhcB292ZXJsYXkpAIteBgCIQgd0byBleHRlbmQAgw0MAIhlGnRoZQCDNRdpcyBzZQCKEAUAh0YIYW5kIGxhdW5jaCBhIE5vZGVKUyB0YXNrIHJ1bm5uAIh-FwCJAAl0aGUAjBcFc3RyYXAuanMgdGVtcGxhAIUoFwAdDWZpbGxlZCBvdQCEdgd2YWx1ZXMgc3BlY2lmaWMAi1UMIGJhc2VkIG9uIGEAiR0FdXAAimEacnVucwAuBwCBDQsAjjYVAIEwCSBhc2tzIGZvcgCBdQVzAIZUB3Nob3VsZCBJIGRvPwCORxZkYXRhIHBhY2tlAI4FBQA2BwCGVyMAj1oSIHBhc3NlcwCNJwUAgH8HAIgeBXRlcnJvZ2F0ZSBoYXJkd2FyAI59Bmxvb3AAgSwFZWFjaCBUYXNrAIt9DACLXwkAkC0Qb3V0cHUAgSMJAJBbBWVuAIYtBgCPQRQAjB4SIACMOgkAhB8FAEkHc3RvcmVkIGFzIGNhdGFsb2dzIGluAI0NCACKbRxpAJA3CCBpAIZIBWZpZ3VyZQCKKwdTS1UgZGVmAI4oBW9ucwCQPQVwcm9jZQCCJAV0aGVzZQBmCnRvIGRldGVybWluZQCRAwVTS1UAWwwAkF0JAFIFAIRcCQCQYgkAZAVlZCwAh0oJAIELBnRpbnUAkGUIAIsaCwCGUw4AkScJAIwvDW4gZW5jbG9zdXIAhTUQdGgAgTAJAIQ-BQAyJWFsc28AjRAISVBNSSBwb2xsZXIAhTAHAJJwCWYgcmVsZXZlbnQgaW5mb3JtYXRpb24gY2FuIGJlIGZvdQCQegUAdwwAjGQWAIVbUU5vdGhpbmcgbW9yZSwgdGhhbmtzIC0gcGxlYXNlIHJlYm9vdACNKgw&s=default
+.. image:: https://www.websequencediagrams.com/cgi-bin/cdraw?lz=dGl0bGUgRGVmYXVsdCBEaXNjb3ZlcnkgV29ya2Zsb3cKU2VydmVyLT5SYWNrSEQ6IERIQ1AgZnJvbSBQWEUobmljIG9yIEJJT1MpCgAdBi0-AC0GOiBJU0MAKQZyZXNwb25zZSB3aXRoIElQCm5vdGUgb3ZlciAAUAcKICAgIElmIHRoZSBub2RlIGlzIGFscmVhZHkgImtub3duIiwAHwVpdCB3aWxsIG9ubHkAUQdkIGkANAVyZSdzIGFuIGFjdGl2ZSB3AIE6CCAgICB0aGF0J3MgYmVlbiBpbnZva2VkIHJlbGF0ZWQgdG8AbgkKZW5kIG5vdGUAgTsRREhDUC1wcm94AG4IAIFGCGJvb3RmaWxlAIIYEVJlcXVlc3QgdG8gZG93bmxvYWQAJAkgdmlhIFRGVFAAgiMRVEZUUCBzZW5kcyByADsGZWQgAC4FKG1vbm9yYWlsLmlweGUpAII5CwCCaQcAgj8FAIMpBiBsb2FkcyAAJQ0Agl4FYW5kIGluaXRpYXRlcyBvbgCBOgVsb2FkZXIAgXIKAINjEElQWEUgc2NyaXB0AIENCHMgd2hhAIFVBwCECAYAhBoGIChodHRwAIERDACDVQwAHQdsb29rcyB1cCBJUCBhZGRyZXNzIG9mIEhUVFAAgW0IAIRcBmkAbgt0byBmaW5kAIQYCnZpYSBpdHMgbWFjLQA_By4AhEIFMSkAhCogAINnXwCBAQYyAHcQbid0IACFRgUAdgpjcmVhdGUgYQCFJAkgKGQAhwQHaXMAhggFABAJJ0dyYXBoLlNrdS4Ahx0JJykAg0wJAIYDCACGXQVhbgCCKxAAg2wIAIYEBS4AhU0aAIJmDCgAg14FAINRB2NhbGxzIGEgUHJvZmlsZSkgKHZpYSAAg10QAIR-DACDMQwAh3MFUmFuY2hlck9TIHZtbGludXoAh0sHbml0cmQAhRUFY2xvdWQtY29uZmlnAIRCCACEfRkAhBgFAIUGCXN0YXRpYwCGJAYtAIhCBQBeESBrZXJuZWwAiRYRABcSAIU-BwBGLFJhAIFVBwCBSQYAShsAgWkHAIYYEQCHLRl0aGUAgToJAIc4CHJkAIoJBmFuZCB0cmFuc2ZlcnMgY29udHJvbCAoYm9vdHMAgmcKAIIrGwCDCwoAh1EJAIJ5DQCBTwsAgxIMAIIqGwCDOQwAgjIXAIQACgCJIgZkAIxuCWRvY2tlciBpbWFnZQCMYAYAjHoGAIlXF3RoZQAyC2NvbnRhaW5lciBpcyBzZQCKdgUAij4HAIl0CWxhdW5jaCBhIE5vZGVKUyB0YXNrIHJ1bm5uAIlmHACJbQl0aGUAi20Fc3RyYXAuanMgdGVtcGxhAIweEwAZDWZpbGxlZCBvdQCGBAd2YWx1ZXMgc3BlY2lmaWMAjHcMIGJhc2VkIG9uIGEAiiQFdXAAi1MXcnVucwArBwCBBgsAiywaAIEuCSBhc2tzIGZvcgCBeAVzAIdhB3Nob3VsZCBJIGRvPwCPORJkYXRhIHBhY2tldCBvZgAxCACHYyAAkDwTICAgIHBhc3NlcwCOEQUAfAd0bwCIBAd0ZXJyb2dhdGUgaGFyZHdhcgCPCAtsb29wAIEyBWVhY2ggVGFzawCMbgwAjXMLAJEjCm91dHB1AIEpCQplbmQAkGoRAJB1BQBIBQAmB3N0b3JlZCBhcyBjYXRhbG9ncyBpbgCNVwgAi1UZSWYAjXoIaQCHAwVmaWd1cmUAiwkHU0tVIGRlZgCOdAVvbnMAkUEJcHJvY2UAggcFdGhlc2UAZwp0byBkZXRlcm1pbmUAkg8FU0tVAF8JAJFiCQBTBQCEOwkAjDoJAGUFZWQsAIgGCQCBDAZ0aW51AJFmCGF0AI4lBlQAhjMNAIx8CQCNDw1uIGVuY2xvc3VyAIUREHRoAIEqCQCEHAUAMiJhbHNvAI1tCElQTUkgcG9sbGVyAIUHBwCTdQcAk2IHZiByZWxldmVudCBpbmZvcm1hdGlvbiBjYW4gYmUgZm91AJFGBQB5DABZJ2dlbmVyAI4HBWFnAGYTAIZ3CXVzZXItAIJGByB0YWdnaW5nIHJ1bGVzAI42CwCGGU1Ob3RoaW5nIG1vcmUsIHRoYW5rcyAtIHBsZWFzZSByZWJvb3QAjm4L&s=modern-blue
 
 The diagram is made with `WebSequenceDiagrams`_.
 
@@ -36,44 +36,72 @@ Default discovery workflow
     title Default Discovery Workflow
     Server->RackHD: DHCP from PXE(nic or BIOS)
     RackHD->Server: ISC DHCP response with IP
+    note over RackHD:
+        If the node is already "known",
+        it will only respond if there's an active workflow
+        that's been invoked related to the node
+    end note
     RackHD->Server: DHCP-proxy response with bootfile
-    note right of RackHD: If the node is already "known", it will only respond if there's an active workflow that's been invoked related to the node
     Server->RackHD: Request to download bootfile via TFTP
     RackHD->Server: TFTP sends requested file (monorail.ipxe)
-    note left of Server: Server loads monorail.ipxe and initiates on bootloader
+    note over Server:
+        Server loads monorail.ipxe
+        and initiates on bootloader
+    end note
     Server->RackHD: IPXE script requests what to do from RackHD (http)
-    note right of RackHD:
-        multiline
+    note over RackHD:
         RackHD looks up IP address of HTTP request from iPXE script to find the node via its mac-address.
-        If the node is already "known", it will only respond if there's an active workflow that's been invoked related to the node
-        If the node isn't known, it will create a workflow (default is the workflow 'Graph.Sku.Discovery') and respond with an iPXE script to initiate that
-        end note
+        1) If the node is already "known", it will only respond if there's an active workflow
+        that's been invoked related to the node.
+        2) If the node isn't known, it will create a workflow (default is the workflow 'Graph.Sku.Discovery')
+        and respond with an iPXE script to initiate that.
+    end note
     RackHD->Server: iPXE script (what RackHD calls a Profile) (via http)
-    note left of Server: iPXE script with discovery microkernel and initrd (http)
-    Server->RackHD: iPXE requests static file - the vmlinuz kernel
-    RackHD->Server: vmlinuz (http)
-    Server->RackHD: iPXE requests static file - initrd
-    RackHD->Server: initrd (http)
-    note left of Server: Server loads the kernel and initrd and transfers control (boots that microkernel)
-    Server->RackHD: initrd loads additional file (overlay) from Server to extend microkernel
-    note left of Server: the discovery microkernel is set to request and launch a NodeJS task runnner
+    note over Server:
+        iPXE script with RancherOS vmlinuz,
+        initrd and cloud-config (http)
+    end note
+    Server->RackHD: iPXE requests static file - the RancherOS vmlinuz kernel
+    RackHD->Server: RancherOS vmlinuz (http)
+    Server->RackHD: iPXE requests static file - RacherOS initrd
+    RackHD->Server: RancherOS initrd (http)
+    note over Server:
+        Server loads the vmlinuz and initrd,
+        and transfers control (boots RancherOS)
+    end note
+    Server->RackHD: RancherOS requests cloud-config - RacherOS cloud-config
+    RackHD->Server: RancherOS cloud-config(http)
+    Server->RackHD: RancherOS loads discovery docker image from Server
+    note over Server:
+        the discovery container is set to request
+        and launch a NodeJS task runnner
+    end note
     Server->RackHD: requests the bootstrap.js template
     RackHD->Server: bootstrap.js filled out with values specific to the node based on a lookup
-    note left of Server: runs node bootstrap.js
+    note over Server:
+        runs node bootstrap.js
+    end note
     Server->RackHD: bootstrap asks for tasks (what should I do?)
     RackHD->Server: data packet of tasks (via http)
-    note left of Server: Discovery Workflow passes down tasks to interrogate hardware
+    note over Server:
+        Discovery Workflow
+        passes down tasks to
+        interrogate hardware
+    end note
     loop for each Task from RackHD
         Server->RackHD: output of task
     end
-    note right of RackHD
-        multiline
-        task output stored as catalogs in RackHD related to the node
-        if RackHD is configured with SKU definitions, it processes these catalogs to determine the SKU
-        if there's a SKU specific workflow defined, control is continued to that
-        the discovery workflow will create an enclosure node based on the catalog data
-        the discovery workflow will also create IPMI pollers for the node if relevent information can be found in the catalog
-        end note
+    note over RackHD
+        Task output stored as catalogs in RackHD related to the node.
+        If RackHD is configured with SKU definitions,
+        it processes these catalogs to determine the SKU.
+        If there's a SKU specific workflow defined, control is continued to that.
+        The discovery workflow will create an enclosure node based on the catalog data.
+        The discovery workflow will also create IPMI pollers for the node,
+        if relevent information can be found in the catalog.
+        The discovery workflow will also generate tag for the node,
+        based on user-defined tagging rules.
+    end note
     Server->RackHD: bootstrap asks for tasks (what should I do?)
     RackHD->Server: Nothing more, thanks - please reboot (via http)
 

--- a/docs/devguide/naming_conventions.rst
+++ b/docs/devguide/naming_conventions.rst
@@ -31,26 +31,26 @@ Examples::
     Graph.Arista.Zerotouch.EOS
 
 
-Overlays
+Microkernel docker image
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Overlay Names**
+**Image Names**
 
-We tend to prefix overlays with *overlayfs_*  along with some information about which
-kernel/base image the overlay was built off and information about what is contained
-within the overlay. Overlays are suffixed with *.cpio.gz* because they are gzipped
-cpio archives.
+We tend to prefix docker images with *micro_*  along with some information about which
+RancherOS the docker image was built off and information about what is contained
+within the docker image. Images are suffixed with *docker.tar.xz* because they are xzed
+tar archives contain docker image.
 
 Examples::
 
-    overlayfs_3.13.0-32_flashupdt.cpio.gz
-    overlayfs_3.13.0-32_brocade.cpio.gz
-    overlayfs_3.13.0-32_all_binaries.cpio.gz
+    micro_1.2.0_flashupdt.docker.tar.xz
+    micro_1.2.0_brocade.docker.tar.xz
+    micro_1.2.0_all_binaries.docker.tar.xz
 
 
-**Overlay Files**
+**Image Files**
 
-When adding scripts and binaries to an overlay, we typically put them in /opt within subdirectories
+When adding scripts and binaries to docker image, we typically put them in /opt within subdirectories
 based on vendor.
 
 Examples::
@@ -65,17 +65,17 @@ then add them to /usr/local/bin or any other directory in the default PATH for b
 
 **File Paths**
 
-Our HTTP server will serve overlay files from /opt/monorail/static/http. It is recommended that you
+Our HTTP server will serve docker images from /opt/monorail/static/http. It is recommended that you
 create subdirectories within this directory for further organization.
 
 Examples::
 
-/opt/monorail/static/http/teamA/intel_flashing/overlayfs_3.13.0-32_flashupdt.cpio.gz
-/opt/monorail/static/http/teamA/generic/overlayfs_3.13.0-32_all_binaries.cpio.gz
+/opt/monorail/static/http/teamA/intel_flashing/micro_1.2.0_flashupdt.docker.tar.xz
+/opt/monorail/static/http/teamA/generic/micro_1.2.0_all_binaries.docker.tar.xz
 
 
 These file paths can then be referenced in workflows starting from the base path
 of /opt/monorail/static/http, so the above paths are referenced for download as::
 
-    teamA/intel_flashing/overlayfs_3.13.0-32_flashupdt.cpio.gz
-    teamA/generic/overlayfs_3.13.0-32_all_binaries.cpio.gz
+    teamA/intel_flashing/micro_1.2.0_flashupdt.docker.tar.xz
+    teamA/generic/micro_1.2.0_all_binaries.docker.tar.xz

--- a/docs/devguide/repositories.rst
+++ b/docs/devguide/repositories.rst
@@ -74,7 +74,7 @@ Supplemental Code
      - A local statsD implementation that makes it easy to deploy on a local machine for aggregating and summarizing application metrics.
    * - ImageBuilder
      - https://github.com/RackHD/on-imagebuilder
-     - Tooling to build RackHD binary files, including the microkernel, specific iPXE builds, and microkernel overlays
+     - Tooling to build RackHD binary files, including the microkernel docker images and specific iPXE builds
    * - SKU Packs
      - https://github.com/RackHD/on-skupack
      - Example SKU pack definitions and example code

--- a/docs/rackhd/configuration.rst
+++ b/docs/rackhd/configuration.rst
@@ -514,38 +514,22 @@ The taskgraph endpoint is the interface that is used by nodes to interacting wit
 Raid Configuration
 ~~~~~~~~~~~~~~~~~~
 
-Setting up the overlay image 
+Setting up the docker image
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For the correct tooling (storcli for Quanta and perccli for Dell) you will to need build the overlay image using the following steps:
+For the correct tooling (storcli for Quanta/Intel and perccli for Dell) you will need to build the docker image using the following steps:
 
 (1). Add the repo https://github.com/RackHD/on-imagebuilder
 
-(2). Make sure there are no previous versions of ansible present:
-   
-.. code-block:: shell
+(2). Refer to the Requirements section of the Readme in the on-imagebuilder repo to install latest version of docker: https://github.com/RackHD/on-imagebuilder#requirements
 
-   sudo pip uninstall ansible
-   sudo dpkg -r
-   sudo apt-get purge ansible
-   sudo pip –U install pip
+(3). For Quanta/Intel storcli - https://github.com/RackHD/on-imagebuilder#oem-tools
 
-(3). Refer to the Requirements section of the Readme in the on-imagebuilder repo to install latest version of ansible: https://github.com/RackHD/on-imagebuilder#requirements
+Refer to the **OEM tools** section:  OEM docker images **raid** and **secure_erase** require storcli_1.17.08_all.deb being copied into raid and secure-erase under on-imagebuilder/oem. User can download it from http://docs.avagotech.com/docs/1.17.08_StorCLI.zip
 
-(4). Refer to the Getting started section to build the default images first https://github.com/RackHD/on-imagebuilder#getting-started
+(4). For Dell PERCcli: https://github.com/RackHD/on-imagebuildera#oem-tools
 
-.. code-block:: shell
-
-   cd on-imagebuilder/
-   sudo ./build_all.sh
-
-(5). For Quanta storcli - https://github.com/RackHD/on-imagebuilder#adding-provisioner-roles-and-configuration-files  
-
-Refer to the NOTE section:  OEM roles provision_raid_overlay and provision_secure_erase_overlay require storcli_1.17.08_all.deb being copied into common/files. User can download it from http://docs.avagotech.com/docs/1.17.08_StorCLI.zip
-
-(6). For Dell PERCcli: https://github.com/RackHD/on-imagebuilder#adding-provisioner-roles-and-configuration-files
-
-Refer to the NOTE section to download and unzip the percCLI package and derive a debian version using ‘alien’ 
+Refer to the **OEM tools** section to download and unzip the percCLI package and derive a debian version using ‘alien’
 There is no .deb version perccli tool. User can download .rpm perccli from https://downloads.dell.com/FOLDER02444760M/1/perccli-1.11.03-1_Linux_A00.tar.gz unzip the package and then use alien to get a .deb version perccli tool as below:
 
 .. code-block:: shell
@@ -553,17 +537,25 @@ There is no .deb version perccli tool. User can download .rpm perccli from https
    sudo apt-get install alien
    sudo alien -k perccli-1.11.03-1.noarch.rpm
 
-OEM roles provision_dell_raid_overlay and provision_secure_erase_overlay require perccli_1.11.03-1_all.deb being copied into common/files in /on-imagebuilder.
+OEM docker images **dell_raid** and **secure_erase** require perccli_1.11.03-1_all.deb being copied into dell-raid and secure-erase under on-imagebuilder/oem.
 
-(7). Build the overlayfs.  This creates the dell.raid.overlay.cpio.gz image in /tmp/on-imagebuilder/builds 
+(5). Build the docker image.
 
 .. code-block:: shell
 
-   sudo ./build_oem.sh 
+    #This creates the dell.raid.docker.tar.xz image
+    cd on-imagebuilder/oem/dell-raid
+    sudo docker build -t rackhd/micro .
+    sudo docker save rackhd/micro | xz -z > dell.raid.docker.tar.xz
 
-(8). Copy the image dell.raid.overlay.cpio.gz to /on-http/static/http/common
+    #This creates the raid.docker.tar.xz image
+    cd on-imagebuilder/oem/raid
+    sudo docker build -t rackhd/micro .
+    sudo docker save rackhd/micro | xz -z > raid.docker.tar.xz
 
-(9). Restart the RackHD service
+(6). Copy the image dell.raid.docker.tar.xz or raid.docker.tar.xz to /on-http/static/http/common
+
+(7). Restart the RackHD service
 
 
 Posting the Workflow

--- a/docs/rackhd/microkernel.rst
+++ b/docs/rackhd/microkernel.rst
@@ -1,149 +1,52 @@
-MicroKernel and Overlays
+MicroKernel image
 ----------------------------------------------------------
 
-RackHD utilizes microkernel images booted in RAM to perform various operations such as node discovery and firmware management.
+RackHD utilizes `RancherOS`_ booted in RAM and a customized docker image run in RancherOS to perform various operations such as node discovery and firmware management.
 
-The `on-imagebuilder`_ repository contains a set of ansible playbooks and roles used for building
-debian-based linux microkernel images and overlay filesystems. They are primarily used with
-the `on-taskgraph`_ workflow engine.
+.. _RancherOS: https://rancher.com/rancher-os
+
+The `on-imagebuilder`_ repository contains a set of scripts that uses `Docker`_ to build
+docker images that run in RancherOS, primarily for use with the `on-taskgraph`_ workflow engine.
 
 .. _on-imagebuilder: https://github.com/rackhd/on-imagebuilder
+.. _Docker: https://www.docker.com
 .. _on-taskgraph: https://github.com/rackhd/on-taskgraph
-
-There are three ansible playbooks included, which build mountable
-`squashfs`_ images, `overlay`_ filesystems, and initrd images.
-
-.. _squashfs: https://en.wikipedia.org/wiki/SquashFS
-.. _overlay: https://en.wikipedia.org/wiki/OverlayFS
 
 Requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Any Debian/Ubuntu-based system (support for other distributions coming soon, however simply installing debootstrap and it should work).
-- ansible is installed (`apt-get install ansible`)
-- Internet access OR network access to an apt cache/proxy server from the build machine
-
-
-Terms
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. list-table::
-   :widths: 20 80
-   :header-rows: 1a
-
-   * - Term
-     - Description
-   * - Base Image
-     - This is a lightweight debian filesystem packaged up as a mountable squashfs image. Essentially, it's just a `debootstrap`_ minbase filesystem with some added configurations and packages. It is ~50mb squashed and occupies ~120mb of space when mounted. The base image[s] are used as a shared image that different overlays can be built and mounted with, and take 3-5 minutes to build.
-   * - overlay filesystem
-     - The overlay filesystem is a gzipped cpio archive of copy-on-write changes made to a mounted base image. Usually an overlay filesystem just contains a few packages and/or shell scripts, and is often under 10mb in size and takes under a minute to build.
-   * - provisioner
-     - An ansible role used to specify changes that should be made to the filesystem of an initrd, base image or overlay (e.g. extra packages, scripts, files).
-
-.. _debootstrap: https://wiki.debian.org/Debootstrap
-
-
-
+- Docker
 
 Bootstrap Process
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The images produced by these playbooks are intended to be netbooted and run in RAM.
+The images produced by these scripts are intended to be netbooted and run in RAM.
 The typical flow for how these images are used/booted is this:
 
-1. Netboot the kernel and initrd via PXE/iPXE.
-2. The custom-built initrd runs a startup script (roles/initrd/provision_initrd/files/local) that requests a base squashfs image and an overlay filesystem from the boot server.
-3. The initrd mounts both images together (union mount) into a tmpfs and boots into that as the root.
-
-The basefs and initrd images are not intended to be changed very often. It's more likely
-that one will add new provisioner roles to build custom overlays that can then be mounted
-with the base image built by the existing ansible roles in this repository.
-
-
+- Netboot **RacherOS** (kernel and initrd) via PXE/iPXE
+- The custom cloud-config file requests a **rackhd/micro** docker image from the boot server.
+- It then starts a container with full container capabilities using the **rackhd/micro** docker image.
 
 Building Images
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Instructions for building images, can be found in the `on-imagebuilder README`_.
 
-
-Adding Provisioner Roles and Configuration Files
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Instructions for adding Provisioner Roles and Configuration Files, can be found `on-imagebuilder README`_.
-
 .. _on-imagebuilder README: https://github.com/RackHD/on-imagebuilder/blob/master/README.md
-
-Changing the Global Configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-All playbooks and roles depend on the variables defined in hosts and group_vars/on_imagebuild.
-These variables specifies the location of the build roots and the apt server/package repositories that are used.
-
-Changing the Build Root
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Update the paths in hosts to the desired build root. The build root paths must be updated in specified in both the *[overlay_build_chroot]* and the *[on_imagebuild:vars]* sections.
-
-
-Changing the Repository URLs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-
-It is highly recommended that an apt-cacher-ng server be used rather than the upstream
-archive.ubuntu.com server that is specified by default. Depending on the network connection,
-this can reduce the build times for the basefs and initrd images by 50%.
-
-To do this:
-
-1. Run *apt-get install apt-cacher-ng*.
-2. Edit the apt_server variable in group_vars/on_imagebuild to equal the address of your apt cache server, for example::
-
-             apt_server: 192.168.100.5:3142
-
-
-The first build will still be slow, because no packages are cached, but subsequent builds will be much faster.
-
-
-**Note:** The playbooks can only be run LOCALLY -- not against remote hosts as
-is usual with Ansible. This is because the chroot ansible_connection type
-used for most builders and provisioners is not supported over ssh and
-other remote ansible_connection types.
-
-
-Why Not Containers?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The goal is to optimize for size on disk and modularity. By creating many
-different overlays that share a base image, we avoid data duplication on the
-boot server (50MB base image + 10 * 5MB overlay archives vs. 10 * 55MB container
-images).
-
-Additionally, it gives us flexibility to update the base image
-and any system dependencies/scripts/etc. on it without having to rebuild
-any overlays. For example, we use a custom rc.local script in the base image
-that is used to receive commands from `workflows`_ on startup. Making
-changes to this script should only have to be done in one place.
-
-.. _workflows: https://github.com/rackhd/on-tasks
-
-Please send us a note if you think this is incorrect! So long as our design
-constraints are preserved, we are more than open to leveraging existing container
-technology.
 
 How To Login Microkernel
 ~~~~~~~~~~~~~~~~~~~~~~~~
-By default, RackHD has a workflow to let users login Ubuntu based microkernel to debug.
-The workflow name is `Graph.BootstrapUbuntu`.
+By default, RackHD has a workflow to let users login RancherOS based microkernel to debug.
+The workflow name is `Graph.BootstrapRancher`.
 
 .. code-block:: REST
 
-    curl -X POST -H 'Content-Type: application/json' <server>/api/current/nodes/<identifier>/workflows?name=Graph.BootstrapUbuntu
+    curl -X POST -H 'Content-Type: application/json' <server>/api/current/nodes/<identifier>/workflows?name=Graph.BootstrapRancher
 
 When this workflow is running, it will set node to PXE boot, then reboot the node.
-The node will boot into Ubuntu microkernel, finally you could SSH login node's microkernel from the RackHD server.
+The node will boot into microkernel, finally you could SSH login node's microkernel from the RackHD server.
 The node's IP address could be retrieved from 'GET /lookups' API like below,
-the SSH username:password is `monorail:monorail`.
+the SSH username:password is `rancher:monorail`.
 
 .. code-block:: REST
 

--- a/docs/rackhd/npm_based_installation.rst
+++ b/docs/rackhd/npm_based_installation.rst
@@ -192,10 +192,9 @@ Install & Configure RackHD
       cd node_modules/on-http/static/http/common
 
       for file in $(echo "\
-      base.trusty.3.16.0-25-generic.squashfs.img \
-      discovery.overlay.cpio.gz \
-      initrd.img-3.16.0-25-generic \
-      vmlinuz-3.16.0-25-generic");do
+      discovery.docker.tar.xz \
+      initrd-1.0.2-rancher \
+      vmlinuz-1.0.2-rancher");do
       wget "https://dl.bintray.com/rackhd/binary/builds/$file"
       done
 
@@ -583,10 +582,9 @@ Install & Configure RackHD
        cd node_modules/on-http/static/http/common
 
        for file in $(echo "\
-       base.trusty.3.16.0-25-generic.squashfs.img \
-       discovery.overlay.cpio.gz \
-       initrd.img-3.16.0-25-generic \
-       vmlinuz-3.16.0-25-generic");do
+       discovery.docker.tar.xz \
+       initrd-1.0.2-rancher \
+       vmlinuz-1.0.2-rancher");do
        wget "https://dl.bintray.com/rackhd/binary/builds/$file"
        done
 

--- a/docs/rackhd/raid_configuration.rst
+++ b/docs/rackhd/raid_configuration.rst
@@ -3,14 +3,14 @@ RAID Configuration
 
 RackHD supports RAID configuration to create and delete RAID for hardwares with LSI RAID controller.
 
-Create overlay with Storcli/Perccli
+Create docker image with Storcli/Perccli
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-RackHD leverages LSI provided tool Storcli to configure RAID. RackHD requires user to build overlay including Storcli.
-As on how to build overlay for RakcHD, please refer to https://github.com/RackHD/on-imagebuilder.
+RackHD leverages LSI provided tool Storcli to configure RAID. RackHD requires user to build docker image including Storcli.
+As on how to build docker image for RakcHD, please refer to https://github.com/RackHD/on-imagebuilder.
 Perccli is a Dell tool which is based on Storcli and has the same commands with it.
-If user wants to configure RAID on Dell servers, Perccli instead of Storcli should be built in overlay.
-The newly built overlay (default named "dell.raid.overlay.cpio.gz" for Dell and "raid.overlay.cpio.gz" for others) should be put in RackHD static file path.
+If user wants to configure RAID on Dell servers, Perccli instead of Storcli should be built in docker image.
+The newly built docker image(default named "dell.raid.docker.tar.xz" for Dell and "raid.docker.tar.xz" for others) should be put in RackHD static file path.
 
 Create RAID
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,7 +34,7 @@ For details on items of create-raid.options, please refer to: https://github.com
 **Note**:
 
 * User need make sure drives are under UGOOD status before creating RAID. If drives are under other status (JBOD, online/offline or UBAD), RackHD won't be able to create RAID with them.
-* For Dell servers, overlay tool path should be specified in param.json as below:
+* For Dell servers, tool path in docker container should be specified in param.json as below:
 
 .. literalinclude:: samples/create-raid-dell.json
    :language: JSON
@@ -62,8 +62,8 @@ An example of params.json for deleting RAID workflow:
             "delete-raid": {
                 "raidIds": [0, 1]
             },
-            "bootstrap": {
-                "overlayfsFile": "raid.overlay.cpio.gz"
+            "bootstrap-rancher": {
+                "dockerFile": "raid.docker.tar.xz"
             }
         }
     }
@@ -81,8 +81,8 @@ For Dell servers, the payload should look like:
                 "path": "/opt/MegaRAID/perccli/percli64",
                 "raidIds": [0, 1]
             },
-            "bootstrap": {
-                "overlayfsFile": "dell.raid.overlay.cpio.gz"
+            "bootstrap-rancher": {
+                "dockerFile": "dell.raid.docker.tar.xz"
             }
         }
     }

--- a/docs/rackhd/samples/boot-settings.json
+++ b/docs/rackhd/samples/boot-settings.json
@@ -3,8 +3,8 @@
         "profile":"defaultboot.ipxe",
         "options":{
             "url":"http://172.31.128.1:9080/common",
-            "kernel":"vmlinuz-3.13.0-32-generic",
-            "initrd":"initrd.img-3.13.0-32-generic",
+            "kernel":"vmlinuz-1.0.2-rancher",
+            "initrd":"initrd-1.0.2-rancher",
             "bootargs":"console=tty0 console=ttyS0,115200n8"
         }
     }

--- a/docs/rackhd/samples/create-raid-dell.json
+++ b/docs/rackhd/samples/create-raid-dell.json
@@ -1,7 +1,7 @@
 {
     "options": {
-        "bootstrap":{
-            "overlayfsFile": "dell-raid.overlay.cpio.gz"
+        "bootstrap-rancher":{
+            "dockerFile": "dell.raid.docker.tar.xz"
         },
         "create-raid": {
             "path": "/opt/MegaRAID/perccli/percli64",

--- a/docs/rackhd/samples/create-raid.json
+++ b/docs/rackhd/samples/create-raid.json
@@ -1,7 +1,7 @@
 {
     "options": {
-        "bootstrap":{
-            "overlayfsFile": "raid.overlay.cpio.gz"
+        "bootstrap-rancher":{
+            "dockerFile": "raid.docker.tar.xz"
         },
         "create-raid": {
             "raidList": [

--- a/docs/rackhd/skus.rst
+++ b/docs/rackhd/skus.rst
@@ -275,7 +275,7 @@ package may have static, template, profile, workflow and task directories.
     config.json
     static/
     static/common/
-    static/common/discovery.overlay.cpio.gz
+    static/common/discovery.docker.tar.xz
     templates/
     templates/ansible.pub
     templates/esx-ks

--- a/docs/rackhd/ubuntu_package_installation.rst
+++ b/docs/rackhd/ubuntu_package_installation.rst
@@ -259,10 +259,9 @@ Downloaded binary files from bintray.com/rackhd/binary and placed them using htt
     cd /var/renasar/on-http/static/http/common
 
     for file in $(echo "\
-    base.trusty.3.16.0-25-generic.squashfs.img \
-    discovery.overlay.cpio.gz \
-    initrd.img-3.16.0-25-generic \
-    vmlinuz-3.16.0-25-generic");do
+    discovery.docker.tar.xz \
+    initrd-1.0.2-rancher \
+    vmlinuz-1.0.2-rancher");do
     wget "https://dl.bintray.com/rackhd/binary/builds/$file"
     done
 

--- a/docs/rackhd/workflow_examples.rst
+++ b/docs/rackhd/workflow_examples.rst
@@ -481,7 +481,7 @@ The catalog object in the above table may look like:
 To use this feature, new workflows and tasks (units of work) must be registered in the system.
 To create a basic workflow that runs user-specified shell commands with specified images, do the following steps:
 
-1. Define a custom workflow task with the images specified to be used (this is not necessary if you don't need to use a custom overlay)::
+1. Define a custom workflow task with the images specified to be used (this is not necessary if you don't need to use a custom image)::
 
        PUT <server>/api/current/workflows/tasks
         Content-Type: application/json
@@ -490,15 +490,13 @@ To create a basic workflow that runs user-specified shell commands with specifie
             "injectableName": "Task.Linux.Bootstrap.Custom",
             "implementsTask": "Task.Base.Linux.Bootstrap",
             "options": {
-               "kernelFile": "vmlinuz-3.13.0-32-generic",
-               "initrdFile": "initrd.img-3.13.0-32-generic",
-               "basefsFile": "base.trusty.3.13.0-32-generic.squashfs.img",
-               "overlayfsFile": "discovery.overlay.cpio.gz",
+               "kernelFile": "vmlinuz-1.0.2-rancher",
+               "initrdFile": "initrd-1.0.2-rancher",
+               "dockerFile": "discovery.docker.tar.xz",
                "kernelUri": "{{ api.server }}/common/{{ options.kernelFile }}",
                "initrdUri": "{{ api.server }}/common/{{ options.initrdFile }}",
-               "basefsUri": "{{ api.server }}/common/{{ options.basefsFile }}",
-               "overlayfsUri": "{{ api.server }}/common/{{ options.overlayfsFile }}",
-               "profile": "linux.ipxe",
+               "dockerUri": "{{ api.server }}/common/{{ options.dockerFile }}",
+               "profile": "rancherOS.ipxe",
                "comport": "ttyS0"
             },
             "properties": {}


### PR DESCRIPTION
**Background**

We need update docs to RancherOS from old Microkernel. It's related with https://rackhd.atlassian.net/browse/RAC-6580.

**Done**

* Update microkernel section
* Update raid configuration
* Update debug guide.

@RackHD/corecommitters @pengz1 @nortonluo 