### PR TITLE
[RAC-6728] Add prerequisite steps for ESXi installation in docker environment

### DIFF
--- a/docs/tutorials/docker-setup.rst
+++ b/docs/tutorials/docker-setup.rst
@@ -17,6 +17,15 @@ Prerequisites
 
 You will need to install `Docker`_ and `Docker Compose`_ before setting up the environment.
 
+If you would try provisioning ESXi on the virtual node, change settings of the kvm module in the host OS.
+
+    .. code::
+
+		rmmod kvm_intel
+		rmmod kvm
+		modprobe kvm ignore_msrs=1
+		modprobe kvm_intel eptad=1 nested=1
+
 You may also want to consider installing `jq`_ which provides a command-line
 oriented tool for pretty printing and filtering JSON structured data.
 


### PR DESCRIPTION
ESXi 5.5/6.0 installation fails in docker demo environment with a kernel panic. Add steps about nested and other settings for kvm related modules in host OS, after which the installation could work correctly.