### PR TITLE
Add RackHD Slack register landing page URL

### DIFF
--- a/docs/to_rackhd.rst
+++ b/docs/to_rackhd.rst
@@ -16,7 +16,7 @@ Communicating with Other Users
 
 We maintain a mailing list at https://groups.google.com/d/forum/rackhd. You can visit the group through the web page or subscribe directly by sending email to rackhd+subscribe@googlegroups.com.
 
-We also have a slack channel at https://rackhd.slack.com to communicate online.
+We also have a slack channel at https://rackhd.slack.com to communicate online. If you want to chat with other community members and contributors, please join the Slack channel at https://slackinviterrackhd.herokuapp.com.
 
 
 Submitting Contributions


### PR DESCRIPTION
Today the RackHD.io link points directly to the RackHD Slack channel. Since Slack is basically a closed system, new users need to be pointed to the registration landing page that was created. 

Added RackHD slack register landing page URL information in "Contributing to RackHD" page.

@mcgG @iceiilin @yaolingling @lanchongyizu 