### PR TITLE
Add ESX 6.5 into RackHD OS Supported Matrix

### DIFF
--- a/docs/server_workflow/os-install/index.rst
+++ b/docs/server_workflow/os-install/index.rst
@@ -26,7 +26,7 @@ Supported OSes and their workflows are listed in table, and the listed versions 
 ============= =========================== =================================================
 OS            Workflow                     Version
 ============= =========================== =================================================
-ESXi          Graph.InstallESXi            5.5/6.0
+ESXi          Graph.InstallESXi            5.5/6.0/6.5
 RHEL          Graph.InstallRHEL            7.0/7.1/7.2
 CentOS        Graph.InstallCentOS          6.5/7
 Ubuntu        Graph.InstallUbuntu          trusty(14.04)/xenial(16.04)/artful(17.10)

--- a/docs/support_matrix.rst
+++ b/docs/support_matrix.rst
@@ -82,7 +82,7 @@ RackHD OS Installation Support List (Qualified by RackHD team)
 ============= =================================================
 OS              Version
 ============= ================================================= 
-ESXi          5.5/6.0
+ESXi          5.5/6.0/6.5
 RHEL          7.0/7.1/7.2
 CentOS        6.5/7
 Ubuntu        trusty(14.04)/xenial(16.04)/artful(17.10)


### PR DESCRIPTION
As ESXi 6.5 installation has been verified by ourselves and community user. So it's good to add ESXi 6.5 into RackHD OS support matrix formally.

@iceiilin @yaolingling @mcgG @lanchongyizu 