### PR TITLE
Supplement NIC prerequisites for installation from Docker

### DIFF
--- a/docs/run_rackhd/docker_based_installation.rst
+++ b/docs/run_rackhd/docker_based_installation.rst
@@ -3,8 +3,63 @@ Installation from Docker
 
 .. contents:: Table of Contents
 
+Prerequisites
+-----------------------------
+
+**NICs**
+
+.. tabs::
+
+    .. tab:: Ubuntu 14.04
+
+        Start with an Ubuntu trusty(14.04) instance with 2 nics:
+
+        * ``eth0`` for the ``public`` network - providing access to RackHD APIs, and providing
+          routed (layer3) access to out of band network for machines under management
+
+        * ``eth1`` for dhcp/pxe to boot/configure the machines
+
+        edit the network:
+
+        * ``eth0`` - assign IP address as appropriate for the environment, or you can use DHCP
+
+        * ``eth1`` static ( 172.31.128.0/22 )
+
+        please check the network config file: ``/etc/network/interfaces``. The ``eth1``'s ip address is ``172.31.128.1`` Like as follows:
+
+        .. code::
+
+            auto eth1
+            iface eth1 inet static
+            address 172.31.128.1
+            post-up ifconfig eth1 promisc
+
+    .. tab:: Ubuntu 16.04
+
+        Start with an Ubuntu xenial(16.04) instance with 2 nics:
+
+        * ``ens160`` for the ``public`` network - providing access to RackHD APIs, and providing
+          routed (layer3) access to out of band network for machines under management
+
+        * ``ens192`` for dhcp/pxe to boot/configure the machines
+
+        edit the network:
+
+        * ``ens160`` - assign IP address as appropriate for the environment, or you can use DHCP
+
+        * ``ens192`` static ( 172.31.128.0/22 )
+
+        please check the network config file: ``/etc/network/interfaces``. The ``ens192``'s ip address is ``172.31.128.1`` Like as follows:
+
+        .. code::
+
+            auto ens192
+            iface ens192 inet static
+            address 172.31.128.1
+            post-up ifconfig ens192 promisc
+
 Install Docker & Docker Compose
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 
 +----------------------+---------------------------------------------------------+
 |Install Docker CE     | https://docs.docker.com/install/#server                 |
@@ -13,7 +68,7 @@ Install Docker & Docker Compose
 +----------------------+---------------------------------------------------------+
 
 Download Source Code
-~~~~~~~~~~~~~~~~~~~~~
+-----------------------------
 
 .. code::
 
@@ -52,7 +107,7 @@ Check RackHD is running properly
 ######
 
 How to Erase the Database to Restart Everything
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------
 
 .. code::
 

--- a/docs/run_rackhd/docker_based_installation.rst
+++ b/docs/run_rackhd/docker_based_installation.rst
@@ -43,13 +43,16 @@ Prerequisites
 
         * ``ens192`` for dhcp/pxe to boot/configure the machines
 
-        edit the network:
+        .. note::
+            You might get different ethernet name from ens160/ens192 in your OS system. Please replace it with what you get accordingly. 
+
+        Edit the network:
 
         * ``ens160`` - assign IP address as appropriate for the environment, or you can use DHCP
 
         * ``ens192`` static ( 172.31.128.0/22 )
 
-        please check the network config file: ``/etc/network/interfaces``. The ``ens192``'s ip address is ``172.31.128.1`` Like as follows:
+        Please check the network config file: ``/etc/network/interfaces``. The ``ens192``'s ip address is ``172.31.128.1`` Like as follows:
 
         .. code::
 

--- a/docs/run_rackhd/npm_based_installation_ubuntu.rst
+++ b/docs/run_rackhd/npm_based_installation_ubuntu.rst
@@ -46,13 +46,16 @@ Prerequisites
 
         * ``ens192`` for dhcp/pxe to boot/configure the machines
 
-        edit the network:
+        .. note::
+            You might get different ethernet name from ens160/ens192 in your OS system. Please replace it with what you get accordingly. 
+
+        Edit the network:
 
         * ``ens160`` - assign IP address as appropriate for the environment, or you can use DHCP
 
         * ``ens192`` static ( 172.31.128.0/22 )
 
-        please check the network config file: ``/etc/network/interfaces``. The ``ens192``'s ip address is ``172.31.128.1`` Like as follows:
+        Please check the network config file: ``/etc/network/interfaces``. The ``ens192``'s ip address is ``172.31.128.1`` Like as follows:
 
         .. code::
 

--- a/docs/run_rackhd/ubuntu_package_installation.rst
+++ b/docs/run_rackhd/ubuntu_package_installation.rst
@@ -44,13 +44,16 @@ NICs
 
         * ``ens192`` for dhcp/pxe to boot/configure the machines
 
-        edit the network:
+        .. note::
+            You might get different ethernet name from ens160/ens192 in your OS system. Please replace it with what you get accordingly. 
+
+        Edit the network:
 
         * ``ens160`` - assign IP address as appropriate for the environment, or you can use DHCP
 
         * ``ens192`` static ( 172.31.128.0/22 )
 
-        please check the network config file: ``/etc/network/interfaces``. The ``ens192``'s ip address is ``172.31.128.1`` Like as follows:
+        Please check the network config file: ``/etc/network/interfaces``. The ``ens192``'s ip address is ``172.31.128.1`` Like as follows:
 
         .. code::
 

--- a/docs/run_rackhd/ubuntu_source_installation.rst
+++ b/docs/run_rackhd/ubuntu_source_installation.rst
@@ -44,13 +44,16 @@ NICs
 
         * ``ens192`` for dhcp/pxe to boot/configure the machines
 
-        edit the network:
+        .. note::
+            You might get different ethernet name from ens160/ens192 in your OS system. Please replace it with what you get accordingly. 
+
+        Edit the network:
 
         * ``ens160`` - assign IP address as appropriate for the environment, or you can use DHCP
 
         * ``ens192`` static ( 172.31.128.0/22 )
 
-        please check the network config file: ``/etc/network/interfaces``. The ``ens192``'s ip address is ``172.31.128.1`` Like as follows:
+        Please check the network config file: ``/etc/network/interfaces``. The ``ens192``'s ip address is ``172.31.128.1`` Like as follows:
 
         .. code::
 


### PR DESCRIPTION
The original RackHD installation from Docker guide missed part of NIC prerequisites which I think should be added.

@linlynn @lanchongyizu 