### PR TITLE
Update PUT statement adding obm setting to node

### DIFF
--- a/docs/rackhd_vlab/discovery.rst
+++ b/docs/rackhd_vlab/discovery.rst
@@ -168,7 +168,7 @@ To talk with BMC, RackHD needs to be configured with the BMC's IP and credential
 
 .. code-block:: shell
 
-    curl -X PUT -H 'Content-Type: application/json' -d ' { "service": "ipmi-obm-service", "config": { "host": "<BMC-IP>", "user": "admin", "password": "admin" } }' localhost:9090/api/current/nodes/<node_id>/obm
+    curl -X PUT -H "Content-Type: application/json" -d '{ "nodeId": "<node_id>", "service": "ipmi-obm-service", "config": { "user": "admin", "password": "admin", "host": "<BMC-IP>" } }' localhost:9090/api/current/nodes/<node_id>/obm
 
 (3) Once the OBM credentials have been configured, RackHD can communicate with BMC in workflows (e.g. power-cycle the BMC or retrieve poller data)
 


### PR DESCRIPTION
Previous statement gave an error while adding ipmi-obm-service to node.  Error read like this:

`{"message":"Validation errors","status":"400","UUID":"9ec269eb-b0bc-4d12-93d5-f5dc2ba46f15","errors":["Missing required property: nodeId"]}`


Requested change properly adds <node-id> property to json structure.