### PR TITLE
Update clone command to also clone submodules

### DIFF
--- a/docs/run_rackhd/docker_based_installation.rst
+++ b/docs/run_rackhd/docker_based_installation.rst
@@ -75,7 +75,7 @@ Download Source Code
 
 .. code::
 
-    git clone https://github.com/RackHD/RackHD
+    git clone --recurse-submodules https://github.com/RackHD/RackHD
 
     cd RackHD/docker
 


### PR DESCRIPTION
If you don't clone submodules but try to run docker-compose up, you receive the error:

ERROR: Cannot locate specified Dockerfile: Dockerfile

It's not obvious what this means without additional debugging